### PR TITLE
Implemented removeCohort API function and testing

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -15,3 +15,4 @@ export { updateVolunteer } from "./updateVolunteer";
 export { updateCohort } from "./updateCohort";
 export { createCohort } from "./createCohort";
 export { getCohorts } from "./getCohorts";
+export { removeCohort } from "./removeCohort";

--- a/src/lib/api/removeCohort.ts
+++ b/src/lib/api/removeCohort.ts
@@ -1,0 +1,53 @@
+import { createClient } from "@/lib/client/supabase";
+
+/**
+ * Removes a cohort from the database by year and term.
+ *
+ * @param year - The cohort year (e.g., 2025)
+ * @param term - The cohort term (e.g., "Fall", "Spring", "Summer", "Winter")
+ *
+ * @returns A Promise resolving to a response object indicating success or failure.
+ *   - On success: { success: true }
+ *   - On failure: { success: false, error: string }
+ *
+ * @example
+ * // Remove the Fall 2025 cohort
+ * const result = await removeCohort(2025, "Fall");
+ * if (result.success) {
+ *   console.log("Cohort deleted successfully");
+ * }
+ */
+type RemoveCohortResponse =
+  | { success: true; error?: never }
+  | { success: false; error: string };
+
+export async function removeCohort(
+  year: number,
+  term: string
+): Promise<RemoveCohortResponse> {
+  const client = await createClient();
+
+  try {
+    const { data, error } = await client
+      .from("Cohorts")
+      .delete()
+      .eq("year", year)
+      .eq("term", term)
+      .select();
+
+    if (error) throw error;
+
+    // No cohort with that year and term was found
+    if (!data || data.length === 0) {
+      return {
+        success: false,
+        error: `Cohort with year ${year} and term ${term} not found`,
+      };
+    }
+
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unexpected error";
+    return { success: false, error: message };
+  }
+}

--- a/tests/lib/api/removeCohort.test.ts
+++ b/tests/lib/api/removeCohort.test.ts
@@ -1,0 +1,185 @@
+// Tests the API function that removes a cohort from the database
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  createServiceTestClient,
+  deleteWhere,
+  deleteWhereGte,
+} from "../support/helpers";
+import {
+  makeTestVolunteerInsert,
+  makeTestCohortInsert,
+  makeTestVolunteerCohortInsert,
+  TEST_YEAR,
+} from "../support/factories";
+import { removeCohort } from "@/lib/api/removeCohort";
+
+describe("removeCohort (integration)", () => {
+  const client = createServiceTestClient();
+
+  // Cleanup before and after each test
+  beforeEach(async () => {
+    // Clean junction tables first, then parent tables
+    await deleteWhere(client, "Volunteers", "name_org", "TEST_%");
+    await deleteWhereGte(client, "Cohorts", "year", TEST_YEAR);
+  });
+
+  afterEach(async () => {
+    await deleteWhere(client, "Volunteers", "name_org", "TEST_%");
+    await deleteWhereGte(client, "Cohorts", "year", TEST_YEAR);
+  });
+
+  describe("successful deletion", () => {
+    it("removes a cohort by year and term and returns success", async () => {
+      // Create a cohort
+      await client
+        .from("Cohorts")
+        .insert(makeTestCohortInsert({ term: "Fall", year: TEST_YEAR }));
+
+      // Remove the cohort
+      const result = await removeCohort(TEST_YEAR, "Fall");
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+
+      // Verify the cohort no longer exists
+      const { data } = await client
+        .from("Cohorts")
+        .select()
+        .eq("year", TEST_YEAR)
+        .eq("term", "Fall");
+
+      expect(data).toHaveLength(0);
+    });
+
+    it("cascades delete to VolunteerCohorts junction table", async () => {
+      // Create a cohort
+      const { data: cohort } = await client
+        .from("Cohorts")
+        .insert(makeTestCohortInsert({ term: "Fall", year: TEST_YEAR }))
+        .select()
+        .single();
+
+      // Create a volunteer
+      const { data: volunteer } = await client
+        .from("Volunteers")
+        .insert(makeTestVolunteerInsert({ name_org: "TEST_Vol_Cascade" }))
+        .select()
+        .single();
+
+      // Link the volunteer to the cohort
+      await client
+        .from("VolunteerCohorts")
+        .insert(makeTestVolunteerCohortInsert(volunteer!.id, cohort!.id));
+
+      // Verify the junction record exists
+      const { data: beforeDelete } = await client
+        .from("VolunteerCohorts")
+        .select()
+        .eq("cohort_id", cohort!.id);
+
+      expect(beforeDelete).toHaveLength(1);
+
+      // Remove the cohort
+      const result = await removeCohort(TEST_YEAR, "Fall");
+
+      expect(result.success).toBe(true);
+
+      // Verify the junction record was cascaded
+      const { data: afterDelete } = await client
+        .from("VolunteerCohorts")
+        .select()
+        .eq("cohort_id", cohort!.id);
+
+      expect(afterDelete).toHaveLength(0);
+
+      // Verify the volunteer still exists
+      const { data: volunteerAfter } = await client
+        .from("Volunteers")
+        .select()
+        .eq("id", volunteer!.id);
+
+      expect(volunteerAfter).toHaveLength(1);
+    });
+  });
+
+  describe("cohort not found", () => {
+    it("returns failure when cohort with year and term does not exist", async () => {
+      const result = await removeCohort(9999, "Fall");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "Cohort with year 9999 and term Fall not found"
+      );
+    });
+
+    it("returns failure when year matches but term does not", async () => {
+      // Create a cohort with a specific term
+      await client
+        .from("Cohorts")
+        .insert(makeTestCohortInsert({ term: "Fall", year: TEST_YEAR }));
+
+      // Try to remove with different term
+      const result = await removeCohort(TEST_YEAR, "Spring");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        `Cohort with year ${TEST_YEAR} and term Spring not found`
+      );
+
+      // Verify the original cohort still exists
+      const { data } = await client
+        .from("Cohorts")
+        .select()
+        .eq("year", TEST_YEAR)
+        .eq("term", "Fall");
+
+      expect(data).toHaveLength(1);
+    });
+
+    it("returns failure when term matches but year does not", async () => {
+      // Create a cohort with a specific year
+      await client
+        .from("Cohorts")
+        .insert(makeTestCohortInsert({ term: "Fall", year: TEST_YEAR }));
+
+      // Try to remove with different year
+      const result = await removeCohort(TEST_YEAR + 1, "Fall");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        `Cohort with year ${TEST_YEAR + 1} and term Fall not found`
+      );
+
+      // Verify the original cohort still exists
+      const { data } = await client
+        .from("Cohorts")
+        .select()
+        .eq("year", TEST_YEAR)
+        .eq("term", "Fall");
+
+      expect(data).toHaveLength(1);
+    });
+  });
+
+  describe("return value structure", () => {
+    it("returns success: true with no error property on successful deletion", async () => {
+      await client
+        .from("Cohorts")
+        .insert(makeTestCohortInsert({ term: "Fall", year: TEST_YEAR }));
+
+      const result = await removeCohort(TEST_YEAR, "Fall");
+
+      expect(result).toEqual({ success: true });
+      expect("error" in result).toBe(false);
+    });
+
+    it("returns success: false with error message on failure", async () => {
+      const result = await removeCohort(9999, "NonExistent");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe("string");
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new API function for removing cohorts from the database, along with comprehensive integration tests to ensure correct behavior. The main focus is on enabling the deletion of a cohort by year and term, handling potential errors, and verifying cascading deletes in related tables.

**Key changes:**

### New API functionality

* Added a new `removeCohort` function in `src/lib/api/removeCohort.ts` that deletes a cohort by year and term, returning a structured success or failure response.
* Exported the new `removeCohort` function from the API index (`src/lib/api/index.ts`) so it can be used elsewhere in the codebase.

### Testing and validation

* Added integration tests in `tests/lib/api/removeCohort.test.ts` to verify:
  - Successful cohort deletion and correct return values.
  - Cascading deletion of related records in the `VolunteerCohorts` junction table.
  - Proper error handling when the cohort does not exist or when year/term mismatches occur.
  - The structure of the API response for both success and failure cases.