### PR TITLE
update role api

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -9,3 +9,4 @@ export { getVolunteersByRoles } from "./getVolunteersByRoles";
 export { createVolunteer } from "./createVolunteer";
 export { getVolunteersTable } from "./getVolunteersTable";
 export { removeRole } from "./removeRole";
+export { updateRole } from "./updateRole";

--- a/src/lib/api/updateRole.ts
+++ b/src/lib/api/updateRole.ts
@@ -1,0 +1,111 @@
+import { createClient } from "@/lib/client/supabase";
+import type { Tables, TablesUpdate } from "@/lib/client/supabase/types";
+
+const ROLE_TYPES = ["prior", "current", "future_interest"] as const;
+
+type RolePatch = Pick<TablesUpdate<"Roles">, "name" | "type" | "is_active">;
+
+type UpdateRoleResult =
+  | { status: 200; body: { role: Tables<"Roles"> } }
+  | { status: 400 | 404 | 409 | 500; body: { error: string } };
+
+const ALLOWED_FIELDS = new Set<keyof RolePatch>(["name", "type", "is_active"]);
+
+function validateRoleUpdateBody(body: unknown): {
+  updates?: RolePatch;
+  error?: string;
+} {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "Request body must be a JSON object" };
+  }
+
+  const payload = body as Record<string, unknown>;
+  const unknownKeys = Object.keys(payload).filter(
+    (key) => !ALLOWED_FIELDS.has(key as keyof RolePatch)
+  );
+
+  if (unknownKeys.length > 0) {
+    return { error: `Unknown field(s): ${unknownKeys.join(", ")}` };
+  }
+
+  const updates: RolePatch = {};
+
+  if ("name" in payload) {
+    const name = payload["name"];
+    if (typeof name !== "string") {
+      return { error: "Field name must be a string" };
+    }
+    if (name.trim().length === 0) {
+      return { error: "Field name cannot be empty" };
+    }
+    updates.name = name.trim();
+  }
+
+  if ("type" in payload) {
+    const type = payload["type"];
+    if (typeof type !== "string") {
+      return { error: "Field type must be a string" };
+    }
+
+    const normalizedType = type.trim();
+    if (!ROLE_TYPES.includes(normalizedType as (typeof ROLE_TYPES)[number])) {
+      return {
+        error: `Field type must be one of ${ROLE_TYPES.join(", ")}`,
+      };
+    }
+
+    updates.type = normalizedType;
+  }
+
+  if ("is_active" in payload) {
+    const isActive = payload["is_active"];
+    if (typeof isActive !== "boolean") {
+      return { error: "Field is_active must be a boolean" };
+    }
+    updates.is_active = isActive;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { error: "At least one updatable field is required" };
+  }
+
+  return { updates };
+}
+
+export async function updateRole(
+  roleId: unknown,
+  body: unknown
+): Promise<UpdateRoleResult> {
+  if (!Number.isInteger(roleId) || (roleId as number) <= 0) {
+    return { status: 400, body: { error: "Invalid role id" } };
+  }
+
+  const validation = validateRoleUpdateBody(body);
+  if (!validation.updates) {
+    return {
+      status: 400,
+      body: { error: validation.error ?? "Invalid role update payload" },
+    };
+  }
+
+  const client = await createClient();
+  const { data, error } = await client
+    .from("Roles")
+    .update(validation.updates)
+    .eq("id", roleId as number)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { status: 409, body: { error: error.message } };
+    }
+    return { status: 500, body: { error: error.message } };
+  }
+
+  if (!data) {
+    return { status: 404, body: { error: "Role not found" } };
+  }
+
+  return { status: 200, body: { role: data } };
+}

--- a/tests/lib/api/updateRole.test.ts
+++ b/tests/lib/api/updateRole.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateRole } from "@/lib/api/updateRole";
+import * as supabaseClient from "@/lib/client/supabase";
+import type { Tables } from "@/lib/client/supabase/types";
+import { createServiceTestClient, deleteWhere } from "../support/helpers";
+import { makeTestRoleInsert } from "../support/factories";
+
+const client = createServiceTestClient();
+
+async function seedRole(
+  overrides: Partial<Tables<"Roles">> = {}
+): Promise<Tables<"Roles">> {
+  const insert = makeTestRoleInsert(overrides);
+  const { data, error } = await client
+    .from("Roles")
+    .insert(insert)
+    .select()
+    .single();
+
+  if (error || !data) {
+    throw error ?? new Error("Failed to seed role");
+  }
+
+  return data;
+}
+
+describe("updateRole (unit)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 400 for invalid role id", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole("bad-id", { name: "TEST_Name" });
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/invalid role id/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object body", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole(1, null);
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/json object/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for unknown field", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole(1, { unknown: "value" });
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/unknown field/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for empty patch object", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole(1, {});
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/at least one updatable field/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid role type", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole(1, { type: "invalid_type" });
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/must be one of/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid is_active type", async () => {
+    const createClientSpy = vi.spyOn(supabaseClient, "createClient");
+    const result = await updateRole(1, { is_active: "true" });
+
+    expect(result.status).toBe(400);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/must be a boolean/i);
+    expect(createClientSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateRole (integration)", () => {
+  beforeEach(async () => {
+    await deleteWhere(client, "Roles", "name", "TEST_%");
+  });
+
+  afterEach(async () => {
+    await deleteWhere(client, "Roles", "name", "TEST_%");
+  });
+
+  it("updates a role and returns the updated object", async () => {
+    const role = await seedRole({ type: "prior", is_active: true });
+
+    const result = await updateRole(role.id, {
+      name: "TEST_Updated_Role",
+      type: "current",
+      is_active: false,
+    });
+
+    expect(result.status).toBe(200);
+    if (result.status !== 200) return;
+
+    expect(result.body.role.id).toBe(role.id);
+    expect(result.body.role.name).toBe("TEST_Updated_Role");
+    expect(result.body.role.type).toBe("current");
+    expect(result.body.role.is_active).toBe(false);
+
+    const { data: persisted, error } = await client
+      .from("Roles")
+      .select()
+      .eq("id", role.id)
+      .single();
+
+    expect(error).toBeNull();
+    expect(persisted).toBeTruthy();
+    expect(persisted!.name).toBe("TEST_Updated_Role");
+    expect(persisted!.type).toBe("current");
+    expect(persisted!.is_active).toBe(false);
+  });
+
+  it("returns 404 when role does not exist", async () => {
+    const result = await updateRole(999999999, { name: "TEST_Missing_Role" });
+
+    expect(result.status).toBe(404);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/role not found/i);
+  });
+
+  it("returns 409 when update violates unique name constraint", async () => {
+    const first = await seedRole({ name: "TEST_Unique_Role_One" });
+    const second = await seedRole({ name: "TEST_Unique_Role_Two" });
+    expect(first.id).not.toBe(second.id);
+
+    const result = await updateRole(second.id, { name: first.name });
+
+    expect(result.status).toBe(409);
+    if (result.status === 200) throw new Error("Expected error response");
+    expect(result.body.error).toMatch(/duplicate|unique/i);
+  });
+
+  it("updates only the provided field(s)", async () => {
+    const role = await seedRole({
+      name: "TEST_Original_Role",
+      type: "future_interest",
+      is_active: true,
+    });
+
+    const result = await updateRole(role.id, { is_active: false });
+
+    expect(result.status).toBe(200);
+    if (result.status !== 200) return;
+    expect(result.body.role.name).toBe("TEST_Original_Role");
+    expect(result.body.role.type).toBe("future_interest");
+    expect(result.body.role.is_active).toBe(false);
+  });
+});


### PR DESCRIPTION
Implemented updateRole API logic and unit + integration tests.




- Input validation happens before creating the Supabase client and invalid payloads return 400
- Function receives a role id and update object, updates the matching role, and returns the updated role object
- Returns 404 when role is not found and 409 on unique-constraint conflicts like a duplicate role name





Before api call:

<img width="1095" height="241" alt="Screenshot 2026-02-13 at 11 14 23 PM" src="https://github.com/user-attachments/assets/31009a76-0bc9-402f-85ef-db7af14901e7" />



After api call:

<img width="1101" height="239" alt="Screenshot 2026-02-13 at 11 18 35 PM" src="https://github.com/user-attachments/assets/4aa60b7d-ae9d-48fc-9fb8-0545a59c4cef" />

