### PR TITLE
Customizable columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "trcc",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.80.0",
         "@tailwindcss/postcss": "^4.1.18",
@@ -111,6 +114,60 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "supabase:migration:up": "npx supabase migration up"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.80.0",
     "@tailwindcss/postcss": "^4.1.18",

--- a/src/app/settings/table/page.tsx
+++ b/src/app/settings/table/page.tsx
@@ -14,7 +14,7 @@ function NoProfileMessage(): React.JSX.Element {
           marginBottom: "0.75rem",
         }}
       >
-        Table Management
+        Volunteers Table Settings
       </h1>
       <p style={{ color: "#525252", lineHeight: 1.5 }}>
         We couldn’t load your profile. Try signing out and back in.
@@ -38,7 +38,7 @@ function AccessDeniedMessage({
           marginBottom: "0.75rem",
         }}
       >
-        Table Management
+        Volunteers Table Settings
       </h1>
       <p style={{ color: "#525252", lineHeight: 1.5 }}>
         {role === "staff"

--- a/src/app/settings/table/page.tsx
+++ b/src/app/settings/table/page.tsx
@@ -1,0 +1,72 @@
+import { getCurrentUserServer } from "@/lib/api/getCurrentUserServer";
+import { listCustomColumns } from "@/lib/api/customColumns";
+import { getVolunteerTableGlobalSettings } from "@/lib/api/volunteerTableGlobalSettings";
+import { TableManagementContent } from "@/components/settings/TableManagementContent";
+
+function NoProfileMessage(): React.JSX.Element {
+  return (
+    <div style={{ maxWidth: "36rem" }}>
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          color: "#171717",
+          marginBottom: "0.75rem",
+        }}
+      >
+        Table Management
+      </h1>
+      <p style={{ color: "#525252", lineHeight: 1.5 }}>
+        We couldn’t load your profile. Try signing out and back in.
+      </p>
+    </div>
+  );
+}
+
+function AccessDeniedMessage({
+  role,
+}: {
+  role: "admin" | "staff" | null;
+}): React.JSX.Element {
+  return (
+    <div style={{ maxWidth: "36rem" }}>
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          color: "#171717",
+          marginBottom: "0.75rem",
+        }}
+      >
+        Table Management
+      </h1>
+      <p style={{ color: "#525252", lineHeight: 1.5 }}>
+        {role === "staff"
+          ? "Only administrators can change which columns are hidden for all users."
+          : "Your account doesn’t have a role yet (admin or staff)."}
+      </p>
+    </div>
+  );
+}
+
+export default async function TableManagementPage(): Promise<React.JSX.Element> {
+  const currentUser = await getCurrentUserServer();
+  if (!currentUser) {
+    return <NoProfileMessage />;
+  }
+  if (currentUser.role !== "admin") {
+    return <AccessDeniedMessage role={currentUser.role} />;
+  }
+
+  const [global, customColumns] = await Promise.all([
+    getVolunteerTableGlobalSettings(),
+    listCustomColumns(),
+  ]);
+
+  return (
+    <TableManagementContent
+      initialAdminHidden={global.admin_hidden_columns}
+      customColumns={customColumns}
+    />
+  );
+}

--- a/src/components/settings/ManageTagsContent.tsx
+++ b/src/components/settings/ManageTagsContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useTransition } from "react";
+import React, { useEffect, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Calendar, ChevronDown, Plus, Tag, Trash2, User } from "lucide-react";
 import clsx from "clsx";
@@ -15,7 +15,9 @@ import {
   removeRoleTagAction,
   updateCohortTagAction,
   updateRoleTagAction,
+  updateCustomColumnAction,
 } from "@/lib/api/actions";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
 
 const ROLE_TYPES = [
   { value: "current", label: "Current" },
@@ -199,22 +201,36 @@ function CollapsibleSection({
 interface ManageTagsContentProps {
   initialRoles: RoleRow[];
   initialCohorts: CohortRow[];
+  /** Custom columns with `data_type === "tag"` — preset options for filters and editors. */
+  initialCustomTagColumns?: CustomColumnRow[];
   loadError: string | null;
   /** When set (e.g. from the volunteers table modal), refreshes client data instead of the Next router. */
   onRefresh?: () => void;
   /** Hides the page title; use inside a dialog that already has a heading. */
   embedded?: boolean;
+  /** When true (e.g. Manage Tags modal), every section starts collapsed. */
+  defaultCollapsed?: boolean;
 }
 
 export function ManageTagsContent({
   initialRoles,
   initialCohorts,
+  initialCustomTagColumns = [],
   loadError,
   onRefresh,
   embedded = false,
+  defaultCollapsed = false,
 }: ManageTagsContentProps): React.JSX.Element {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+
+  /** Roles, cohorts, and custom tag blocks all start closed when this is true. */
+  const sectionsStartClosed = defaultCollapsed === true || embedded === true;
+
+  const tagColumns = useMemo(
+    () => initialCustomTagColumns.filter((c) => c.data_type === "tag"),
+    [initialCustomTagColumns]
+  );
 
   const [roles, setRoles] = useState(initialRoles);
   const [cohorts, setCohorts] = useState(initialCohorts);
@@ -231,8 +247,18 @@ export function ManageTagsContent({
     String(new Date().getFullYear())
   );
 
-  const [openRoles, setOpenRoles] = useState(true);
-  const [openCohorts, setOpenCohorts] = useState(true);
+  const [openRoles, setOpenRoles] = useState(() => !sectionsStartClosed);
+  const [openCohorts, setOpenCohorts] = useState(() => !sectionsStartClosed);
+
+  const [tagOptionDrafts, setTagOptionDrafts] = useState<
+    Record<number, string[]>
+  >({});
+  const [newTagOptionByColumnId, setNewTagOptionByColumnId] = useState<
+    Record<number, string>
+  >({});
+  const [openCustomTagById, setOpenCustomTagById] = useState<
+    Record<number, boolean>
+  >({});
 
   useEffect(() => {
     setRoles(initialRoles);
@@ -242,21 +268,62 @@ export function ManageTagsContent({
     setCohorts(initialCohorts);
   }, [initialCohorts]);
 
+  /** Keep in-progress edits when `roles` refreshes (e.g. after creating another role). */
   useEffect(() => {
-    setRoleDrafts(
-      Object.fromEntries(
-        roles.map((r) => [r.id, { name: r.name, type: r.type }])
-      )
-    );
+    setRoleDrafts((prev) => {
+      const next: Record<number, RoleDraft> = {};
+      for (const r of roles) {
+        const fromServer: RoleDraft = { name: r.name, type: r.type };
+        const p = prev[r.id];
+        if (p && (p.name !== fromServer.name || p.type !== fromServer.type)) {
+          next[r.id] = p;
+        } else {
+          next[r.id] = fromServer;
+        }
+      }
+      return next;
+    });
   }, [roles]);
 
+  /** Keep in-progress edits when `cohorts` refreshes (e.g. after creating another cohort). */
   useEffect(() => {
-    setCohortDrafts(
-      Object.fromEntries(
-        cohorts.map((c) => [c.id, { term: c.term, year: String(c.year) }])
-      )
-    );
+    setCohortDrafts((prev) => {
+      const next: Record<number, CohortDraft> = {};
+      for (const c of cohorts) {
+        const fromServer: CohortDraft = {
+          term: c.term,
+          year: String(c.year),
+        };
+        const p = prev[c.id];
+        if (p && (p.term !== fromServer.term || p.year !== fromServer.year)) {
+          next[c.id] = p;
+        } else {
+          next[c.id] = fromServer;
+        }
+      }
+      return next;
+    });
   }, [cohorts]);
+
+  /**
+   * When custom tag columns reload, keep local edits that are not yet on the server
+   * (e.g. user typed in a cell but did not click “Save option edits” before another action).
+   */
+  useEffect(() => {
+    setTagOptionDrafts((prev) => {
+      const next: Record<number, string[]> = {};
+      for (const c of tagColumns) {
+        const fromServer = [...(c.tag_options ?? [])];
+        const p = prev[c.id];
+        if (p && JSON.stringify(p) !== JSON.stringify(fromServer)) {
+          next[c.id] = p;
+        } else {
+          next[c.id] = fromServer;
+        }
+      }
+      return next;
+    });
+  }, [tagColumns]);
 
   const refresh = (): void => {
     if (onRefresh) {
@@ -475,6 +542,96 @@ export function ManageTagsContent({
     if (!row || !d) return false;
     const y = parseInt(d.year, 10);
     return row.term !== d.term || row.year !== y;
+  };
+
+  const tagColumnDirty = (columnId: number): boolean => {
+    const col = tagColumns.find((c) => c.id === columnId);
+    const draft = tagOptionDrafts[columnId];
+    if (!col || draft === undefined) return false;
+    return JSON.stringify(col.tag_options ?? []) !== JSON.stringify(draft);
+  };
+
+  const handleSaveTagColumnOptions = (columnId: number): void => {
+    const draft = tagOptionDrafts[columnId];
+    if (draft === undefined) return;
+    startTransition(async () => {
+      const res = await updateCustomColumnAction(columnId, {
+        tag_options: draft,
+      });
+      if (res.success) {
+        toast.success("Tag options saved");
+        refresh();
+      } else {
+        toast.error(res.error ?? "Could not save tag options");
+      }
+    });
+  };
+
+  const handleRemoveTagOptionAt = (columnId: number, index: number): void => {
+    const draft = [...(tagOptionDrafts[columnId] ?? [])];
+    draft.splice(index, 1);
+    setTagOptionDrafts((prev) => ({ ...prev, [columnId]: draft }));
+    startTransition(async () => {
+      const res = await updateCustomColumnAction(columnId, {
+        tag_options: draft,
+      });
+      if (res.success) {
+        toast.success("Option removed");
+        refresh();
+      } else {
+        toast.error(res.error ?? "Could not update options");
+        const col = tagColumns.find((c) => c.id === columnId);
+        setTagOptionDrafts((prev) => ({
+          ...prev,
+          [columnId]: [...(col?.tag_options ?? [])],
+        }));
+      }
+    });
+  };
+
+  const handleAddCustomTagOption = (
+    e: React.FormEvent,
+    columnId: number
+  ): void => {
+    e.preventDefault();
+    const raw = (newTagOptionByColumnId[columnId] ?? "").trim();
+    if (!raw) {
+      toast.error("Enter a tag option");
+      return;
+    }
+    const prev = [...(tagOptionDrafts[columnId] ?? [])];
+    if (prev.some((p) => p.toLowerCase() === raw.toLowerCase())) {
+      toast.error("That option already exists");
+      return;
+    }
+    const draft = [...prev, raw];
+    setTagOptionDrafts((p) => ({ ...p, [columnId]: draft }));
+    setNewTagOptionByColumnId((p) => ({ ...p, [columnId]: "" }));
+    startTransition(async () => {
+      const res = await updateCustomColumnAction(columnId, {
+        tag_options: draft,
+      });
+      if (res.success) {
+        toast.success("Option added");
+        refresh();
+      } else {
+        toast.error(res.error ?? "Could not add option");
+        setTagOptionDrafts((p) => ({
+          ...p,
+          [columnId]: prev,
+        }));
+      }
+    });
+  };
+
+  const isCustomTagSectionOpen = (columnId: number): boolean =>
+    openCustomTagById[columnId] ?? !sectionsStartClosed;
+
+  const toggleCustomTagSection = (columnId: number): void => {
+    setOpenCustomTagById((prev) => ({
+      ...prev,
+      [columnId]: !(prev[columnId] ?? !sectionsStartClosed),
+    }));
   };
 
   if (loadError) {
@@ -817,6 +974,140 @@ export function ManageTagsContent({
           </button>
         </div>
       </CollapsibleSection>
+
+      {tagColumns.map((col) => {
+        const opts = tagOptionDrafts[col.id] ?? [];
+        return (
+          <CollapsibleSection
+            key={col.id}
+            sectionId={`manage-tags-custom-tag-${col.id}`}
+            title={col.name}
+            subtitle={
+              col.is_multi
+                ? "Preset options for this multi-select tag column"
+                : "Preset options for this tag column"
+            }
+            icon={Tag}
+            count={opts.length}
+            open={isCustomTagSectionOpen(col.id)}
+            onToggle={() => toggleCustomTagSection(col.id)}
+            embedded={embedded}
+          >
+            <div className="overflow-x-auto rounded-xl border border-gray-200/90 bg-white shadow-inner shadow-gray-100/80">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-gray-100/70 text-[11px] font-semibold uppercase tracking-wider text-gray-500 border-b border-gray-200/90">
+                  <tr>
+                    <th className="px-3 py-2.5 pl-4">Option</th>
+                    <th className="px-3 py-2.5 pr-4 text-right whitespace-nowrap w-[1%] min-w-32">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100/90 bg-white">
+                  {opts.length === 0 ? (
+                    <tr>
+                      <td colSpan={2} className="px-4 py-8">
+                        <p className="text-sm text-gray-500 text-center">
+                          No preset options yet. Add one below or type new
+                          values in the table when editing volunteers.
+                        </p>
+                      </td>
+                    </tr>
+                  ) : (
+                    opts.map((opt, index) => (
+                      <tr
+                        key={`${col.id}-opt-${index}`}
+                        className="hover:bg-purple-50/25 transition-colors"
+                      >
+                        <td className="px-3 py-2.5 pl-4 align-middle">
+                          <input
+                            type="text"
+                            className={inputClass + " w-full min-w-32"}
+                            value={opt}
+                            onChange={(e) => {
+                              const next = [...(tagOptionDrafts[col.id] ?? [])];
+                              next[index] = e.target.value;
+                              setTagOptionDrafts((prev) => ({
+                                ...prev,
+                                [col.id]: next,
+                              }));
+                            }}
+                          />
+                        </td>
+                        <td className="px-3 py-2.5 pr-4 align-middle text-right whitespace-nowrap w-[1%]">
+                          <button
+                            type="button"
+                            disabled={isPending}
+                            onClick={() =>
+                              handleRemoveTagOptionAt(col.id, index)
+                            }
+                            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-red-200/90 bg-white px-2 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50"
+                            title="Remove option"
+                          >
+                            <Trash2
+                              className="h-3.5 w-3.5 shrink-0"
+                              aria-hidden
+                            />
+                            Remove
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="rounded-xl border border-dashed border-purple-200/70 bg-purple-50/25 p-4 sm:p-5">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-purple-900/80 mb-3">
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+                Add option
+              </p>
+              <form
+                onSubmit={(e) => handleAddCustomTagOption(e, col.id)}
+                className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end"
+              >
+                <div className="flex flex-col gap-1 flex-1 min-w-40">
+                  <label className="text-xs font-medium text-gray-600">
+                    Label
+                  </label>
+                  <input
+                    type="text"
+                    className={inputClass + " w-full"}
+                    value={newTagOptionByColumnId[col.id] ?? ""}
+                    onChange={(e) =>
+                      setNewTagOptionByColumnId((prev) => ({
+                        ...prev,
+                        [col.id]: e.target.value,
+                      }))
+                    }
+                    placeholder="e.g. Small"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={isPending}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-accent-purple px-4 py-2.5 text-sm font-medium text-white shadow-md shadow-purple-900/10 hover:bg-dark-accent-purple disabled:opacity-50 sm:shrink-0"
+                >
+                  <Plus className="h-4 w-4" aria-hidden />
+                  Add
+                </button>
+              </form>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-200/80 pt-3 mt-3">
+              <button
+                type="button"
+                disabled={isPending || !tagColumnDirty(col.id)}
+                onClick={() => handleSaveTagColumnOptions(col.id)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-accent-purple px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-dark-accent-purple disabled:opacity-40"
+              >
+                Save option edits
+              </button>
+            </div>
+          </CollapsibleSection>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/settings/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 const NAV_ITEMS = [
   { href: "/settings/account", label: "Account Info" },
   { href: "/settings/manage", label: "Manage Users" },
+  { href: "/settings/table", label: "Table Management" },
 ] as const;
 
 export function SettingsNav(): React.JSX.Element {

--- a/src/components/settings/SettingsNav.tsx
+++ b/src/components/settings/SettingsNav.tsx
@@ -7,7 +7,7 @@ import { usePathname } from "next/navigation";
 const NAV_ITEMS = [
   { href: "/settings/account", label: "Account Info" },
   { href: "/settings/manage", label: "Manage Users" },
-  { href: "/settings/table", label: "Table Management" },
+  { href: "/settings/table", label: "Table Settings" },
 ] as const;
 
 export function SettingsNav(): React.JSX.Element {

--- a/src/components/settings/TableManagementContent.tsx
+++ b/src/components/settings/TableManagementContent.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
-import { Columns3, Info, LayoutList, Loader2, Sparkles } from "lucide-react";
+import { Columns3, EyeOff, Info, Loader2, Plus, Trash2 } from "lucide-react";
 import {
   COLUMNS_CONFIG,
   tableIdForCustomColumn,
 } from "@/components/volunteers/volunteerColumns";
-import type { CustomColumnRow } from "@/lib/api/customColumns";
-import { saveVolunteerTableGlobalSettingsAction } from "@/lib/api/actions";
+import type {
+  CustomColumnRow,
+  NewCustomColumnInput,
+} from "@/lib/api/customColumns";
+import {
+  createCustomColumnsAction,
+  deleteCustomColumnsAction,
+  saveVolunteerTableGlobalSettingsAction,
+} from "@/lib/api/actions";
 import {
   NON_HIDEABLE_COLUMN_IDS,
   sanitizeHiddenColumnIds,
@@ -18,8 +26,159 @@ type Row = { id: string; label: string };
 
 const NON_HIDEABLE_SET = new Set(NON_HIDEABLE_COLUMN_IDS);
 
+/** Drop org-hidden ids that no longer match a built-in or current custom column (e.g. after a column was deleted). */
+function filterAdminHiddenToExistingColumns(
+  adminHidden: string[],
+  customColumns: CustomColumnRow[]
+): Set<string> {
+  const listed = new Set<string>();
+  for (const c of COLUMNS_CONFIG) {
+    if (!NON_HIDEABLE_SET.has(String(c.id))) {
+      listed.add(String(c.id));
+    }
+  }
+  for (const col of customColumns) {
+    listed.add(tableIdForCustomColumn(col.column_key));
+  }
+  return new Set(
+    sanitizeHiddenColumnIds(adminHidden).filter((id) => listed.has(id))
+  );
+}
+
 function serializeHidden(s: Set<string>): string {
   return JSON.stringify([...s].sort());
+}
+
+const settingsPanelStyle: React.CSSProperties = {
+  marginBottom: "1.5rem",
+  padding: "1.25rem",
+  borderRadius: "10px",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "#e5e5e5",
+  backgroundColor: "#ffffff",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.06)",
+};
+
+const panelIconWrapStyle: React.CSSProperties = {
+  width: 36,
+  height: 36,
+  borderRadius: "8px",
+  backgroundColor: "var(--trcc-light-purple, #ede9fe)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+};
+
+const panelTitleStyle: React.CSSProperties = {
+  fontSize: "1rem",
+  fontWeight: 600,
+  color: "#171717",
+  margin: 0,
+  lineHeight: 1.3,
+};
+
+const panelDescriptionStyle: React.CSSProperties = {
+  fontSize: "0.8125rem",
+  color: "#737373",
+  margin: "0.35rem 0 0",
+  lineHeight: 1.5,
+  maxWidth: "52rem",
+};
+
+const subsectionHeadingRow: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  marginBottom: "0.5rem",
+};
+
+const subsectionTitleStyle: React.CSSProperties = {
+  fontSize: "0.8125rem",
+  fontWeight: 600,
+  color: "#525252",
+  margin: 0,
+};
+
+const subsectionHintStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#737373",
+  margin: "0 0 0.75rem",
+  lineHeight: 1.5,
+  maxWidth: "40rem",
+};
+
+const fieldLabelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.75rem",
+  fontWeight: 500,
+  color: "#404040",
+  marginBottom: "0.25rem",
+};
+
+const fieldControlStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  padding: "0.5rem 0.625rem",
+  fontSize: "0.875rem",
+  borderRadius: "6px",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "#e5e5e5",
+  backgroundColor: "#fff",
+};
+
+const panelFooterRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  gap: "0.75rem",
+  marginTop: "1.25rem",
+  paddingTop: "1rem",
+  borderTop: "1px solid #e5e5e5",
+};
+
+function SettingsSection({
+  sectionId,
+  title,
+  description,
+  icon,
+  iconFrameStyle,
+  children,
+  footer,
+}: {
+  sectionId: string;
+  title: string;
+  description: React.ReactNode;
+  icon: React.ReactNode;
+  /** Merged onto the default icon tile (e.g. danger tint for remove section). */
+  iconFrameStyle?: React.CSSProperties;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <section style={settingsPanelStyle} aria-labelledby={sectionId}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: "0.75rem",
+          marginBottom: "1rem",
+        }}
+      >
+        <div style={{ ...panelIconWrapStyle, ...iconFrameStyle }}>{icon}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h2 id={sectionId} style={panelTitleStyle}>
+            {title}
+          </h2>
+          <div style={panelDescriptionStyle}>{description}</div>
+        </div>
+      </div>
+      {children}
+      {footer}
+    </section>
+  );
 }
 
 const rowBaseStyle: React.CSSProperties = {
@@ -31,7 +190,9 @@ const rowBaseStyle: React.CSSProperties = {
   padding: "0.75rem 1rem",
   marginBottom: "0.5rem",
   borderRadius: "6px",
-  border: "1px solid #e5e5e5",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "#e5e5e5",
   backgroundColor: "#fff",
 };
 
@@ -141,6 +302,89 @@ function ColumnToggleRow({
   );
 }
 
+function customColumnTypeLabel(c: CustomColumnRow): string {
+  if (c.data_type === "tag") {
+    return c.is_multi ? "Tags (multiple)" : "Tag";
+  }
+  if (c.data_type === "boolean") return "Yes / No";
+  if (c.data_type === "number") return "Number";
+  return "Text";
+}
+
+function CustomColumnDeleteRow({
+  column,
+  disabled,
+  onRequestRemove,
+}: {
+  column: CustomColumnRow;
+  disabled: boolean;
+  onRequestRemove: () => void;
+}): React.JSX.Element {
+  const tid = tableIdForCustomColumn(column.column_key);
+  return (
+    <div style={rowBaseStyle}>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <p
+          style={{
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            color: "#171717",
+            margin: 0,
+          }}
+        >
+          {column.name}
+        </p>
+        <p
+          style={{
+            margin: "0.25rem 0 0",
+            fontFamily: "ui-monospace, monospace",
+            fontSize: "0.6875rem",
+            color: "#737373",
+            wordBreak: "break-all",
+          }}
+        >
+          {tid}
+        </p>
+        <p
+          style={{
+            margin: "0.35rem 0 0",
+            fontSize: "0.6875rem",
+            color: "#a3a3a3",
+          }}
+        >
+          {customColumnTypeLabel(column)}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRequestRemove}
+        disabled={disabled}
+        aria-label={`Remove column ${column.name}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.35rem",
+          flexShrink: 0,
+          padding: "0.4rem 0.75rem",
+          borderRadius: "6px",
+          borderWidth: "1px",
+          borderStyle: "solid",
+          borderColor: "#fecaca",
+          backgroundColor: "#fff",
+          color: "#b91c1c",
+          fontSize: "0.8125rem",
+          fontWeight: 500,
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        <Trash2 style={{ width: 14, height: 14 }} aria-hidden />
+        Remove
+      </button>
+    </div>
+  );
+}
+
 export function TableManagementContent({
   initialAdminHidden,
   customColumns,
@@ -148,6 +392,17 @@ export function TableManagementContent({
   initialAdminHidden: string[];
   customColumns: CustomColumnRow[];
 }): React.JSX.Element {
+  const router = useRouter();
+  const [newName, setNewName] = useState("");
+  const [newType, setNewType] =
+    useState<NewCustomColumnInput["data_type"]>("text");
+  const [tagOptionsRaw, setTagOptionsRaw] = useState("");
+  const [tagMulti, setTagMulti] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDeleteColumn, setConfirmDeleteColumn] =
+    useState<CustomColumnRow | null>(null);
+
   const builtInRows: Row[] = useMemo(
     () =>
       COLUMNS_CONFIG.filter((c) => !NON_HIDEABLE_SET.has(String(c.id))).map(
@@ -168,19 +423,30 @@ export function TableManagementContent({
     [customColumns]
   );
 
-  const [hidden, setHidden] = useState<Set<string>>(() => {
-    return new Set(sanitizeHiddenColumnIds(initialAdminHidden));
-  });
+  const [hidden, setHidden] = useState<Set<string>>(() =>
+    filterAdminHiddenToExistingColumns(initialAdminHidden, customColumns)
+  );
   const [savedSignature, setSavedSignature] = useState(() =>
-    serializeHidden(new Set(sanitizeHiddenColumnIds(initialAdminHidden)))
+    serializeHidden(
+      filterAdminHiddenToExistingColumns(initialAdminHidden, customColumns)
+    )
   );
   const [saving, setSaving] = useState(false);
 
+  const customColumnIdsKey = useMemo(
+    () => customColumns.map((c) => c.id).join(","),
+    [customColumns]
+  );
+
   useEffect(() => {
-    const next = new Set(sanitizeHiddenColumnIds(initialAdminHidden));
+    const next = filterAdminHiddenToExistingColumns(
+      initialAdminHidden,
+      customColumns
+    );
     setHidden(next);
     setSavedSignature(serializeHidden(next));
-  }, [initialAdminHidden]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- customColumnIdsKey tracks custom column set; omitting `customColumns` avoids resets when the parent passes a new array reference with the same columns
+  }, [initialAdminHidden, customColumnIdsKey]);
 
   const isDirty = serializeHidden(hidden) !== savedSignature;
 
@@ -210,27 +476,77 @@ export function TableManagementContent({
     }
   };
 
-  const sectionHeadingStyle: React.CSSProperties = {
-    display: "flex",
-    alignItems: "center",
-    gap: "0.5rem",
-    marginBottom: "0.5rem",
+  const handleCreateCustomColumn = async (): Promise<void> => {
+    const name = newName.trim();
+    if (!name) {
+      toast.error("Enter a column name");
+      return;
+    }
+    let payload: NewCustomColumnInput;
+    if (newType === "tag") {
+      const tag_options = tagOptionsRaw
+        .split(/[,|\n]/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      payload = {
+        name,
+        data_type: "tag",
+        tag_options,
+        is_multi: tagMulti,
+      };
+    } else {
+      payload = { name, data_type: newType };
+    }
+    setCreating(true);
+    try {
+      const results = await createCustomColumnsAction([payload]);
+      const r = results[0];
+      if (!r) {
+        toast.error("No response from server");
+        return;
+      }
+      if (r.success) {
+        toast.success(`Column “${r.label}” created`);
+        setNewName("");
+        setNewType("text");
+        setTagOptionsRaw("");
+        setTagMulti(false);
+        router.refresh();
+      } else {
+        toast.error(r.error ?? `Could not create “${r.label}”`);
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Create failed");
+    } finally {
+      setCreating(false);
+    }
   };
 
-  const sectionTitleStyle: React.CSSProperties = {
-    fontSize: "0.875rem",
-    fontWeight: 600,
-    color: "#404040",
-    margin: 0,
+  const handleConfirmDeleteColumn = async (): Promise<void> => {
+    if (!confirmDeleteColumn) return;
+    setDeleting(true);
+    try {
+      const results = await deleteCustomColumnsAction([confirmDeleteColumn.id]);
+      const r = results[0];
+      if (!r) {
+        toast.error("No response from server");
+        return;
+      }
+      if (r.success) {
+        toast.success(`Removed column “${confirmDeleteColumn.name}”`);
+        setConfirmDeleteColumn(null);
+        router.refresh();
+      } else {
+        toast.error(r.error ?? `Could not remove “${r.label}”`);
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Remove failed");
+    } finally {
+      setDeleting(false);
+    }
   };
 
-  const sectionHintStyle: React.CSSProperties = {
-    fontSize: "0.75rem",
-    color: "#737373",
-    margin: "0 0 0.75rem",
-    lineHeight: 1.5,
-    maxWidth: "40rem",
-  };
+  const busy = saving || creating || deleting;
 
   return (
     <div>
@@ -272,18 +588,18 @@ export function TableManagementContent({
                 fontSize: "1.25rem",
                 fontWeight: 700,
                 color: "#171717",
-                margin: 0,
+                margin: "0.2rem 0 0",
               }}
             >
-              Table Management
+              Volunteers Table Settings
             </h1>
             <p
               style={{
                 fontSize: "0.8125rem",
                 color: "#737373",
-                margin: "0.25rem 0 0",
+                margin: "0.35rem 0 0",
                 lineHeight: 1.5,
-                maxWidth: "36rem",
+                maxWidth: "64rem",
               }}
             >
               <span style={{ color: "#404040", fontWeight: 600 }}>
@@ -291,9 +607,12 @@ export function TableManagementContent({
                 {builtInRows.length + customRows.length === 1 ? "" : "s"}
               </span>
               <span style={{ color: "#a3a3a3" }}> · </span>
-              Choose which columns are hidden for every signed-in user on the
-              volunteers dashboard. Personal “Manage columns” settings can hide
-              additional columns on top of this list.
+              Configure organization-wide settings for the volunteers table:
+              hide columns for everyone, add custom columns, or delete custom
+              columns and their data. Any user can still personalize visibility
+              and reorder columns in the{" "}
+              <span style={{ fontStyle: "italic" }}>Manage columns</span> pop-up
+              in the table.
             </p>
           </div>
         </div>
@@ -331,138 +650,460 @@ export function TableManagementContent({
         </p>
       </div>
 
-      <div style={{ marginBottom: "2rem" }}>
-        <div style={sectionHeadingStyle}>
-          <LayoutList
-            style={{ width: 16, height: 16, color: "#737373" }}
+      <SettingsSection
+        sectionId="hide-columns-heading"
+        title="Hide columns for everyone"
+        description={
+          <>
+            Turn a switch on to hide that column for every signed-in user. Use{" "}
+            <strong>Save changes</strong> in the footer of this panel to apply
+            visibility updates.
+          </>
+        }
+        icon={
+          <EyeOff
+            style={{
+              width: 18,
+              height: 18,
+              color: "var(--trcc-purple, #7c3aed)",
+            }}
             aria-hidden
           />
-          <h2 id="builtin-heading" style={sectionTitleStyle}>
-            Built-in columns
-          </h2>
-        </div>
-        <p style={sectionHintStyle}>
-          Standard volunteer fields. Turn the switch on to hide a column for the
-          whole team.
-        </p>
-        <div>
-          {builtInRows.map((row) => (
-            <ColumnToggleRow
-              key={row.id}
-              row={row}
-              isHidden={hidden.has(row.id)}
-              disabled={saving}
-              onToggle={() => toggle(row.id)}
-            />
-          ))}
-        </div>
-      </div>
-
-      {customRows.length > 0 && (
-        <div style={{ marginBottom: "2rem" }}>
-          <div style={sectionHeadingStyle}>
-            <Sparkles
+        }
+        footer={
+          <div style={panelFooterRowStyle}>
+            <span
               style={{
-                width: 16,
-                height: 16,
-                color: "var(--trcc-purple, #7c3aed)",
+                marginRight: "auto",
+                fontSize: "0.875rem",
+                color: isDirty ? "#92400e" : "#525252",
+                fontWeight: isDirty ? 500 : 400,
               }}
-              aria-hidden
-            />
-            <h2 id="custom-heading" style={sectionTitleStyle}>
-              Custom columns
-            </h2>
+            >
+              {hiddenCount === 0 ? (
+                <span style={{ color: "#15803d" }}>
+                  All listed columns visible.
+                </span>
+              ) : (
+                <>
+                  <span style={{ fontWeight: 600, color: "#171717" }}>
+                    {hiddenCount}
+                  </span>{" "}
+                  column{hiddenCount === 1 ? "" : "s"} hidden for everyone
+                </>
+              )}
+              {isDirty && (
+                <span style={{ marginLeft: "0.5rem", color: "#b45309" }}>
+                  · Unsaved changes
+                </span>
+              )}
+            </span>
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={busy || !isDirty}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                padding: "0.5rem 1rem",
+                borderRadius: "6px",
+                backgroundColor:
+                  busy || !isDirty ? "#d4d4d4" : "var(--trcc-purple, #7c3aed)",
+                color: "#fff",
+                border: "none",
+                fontWeight: 500,
+                cursor: busy || !isDirty ? "not-allowed" : "pointer",
+                fontSize: "0.875rem",
+              }}
+            >
+              {saving ? (
+                <>
+                  <Loader2
+                    style={{ width: 16, height: 16 }}
+                    className="animate-spin"
+                    aria-hidden
+                  />
+                  Saving…
+                </>
+              ) : (
+                "Save changes"
+              )}
+            </button>
           </div>
-          <p style={sectionHintStyle}>
-            Fields your organization added in Manage columns. You can hide them
-            here without deleting stored data.
+        }
+      >
+        <div style={{ marginBottom: "1.25rem" }}>
+          <div style={subsectionHeadingRow}>
+            <h3 id="builtin-heading" style={subsectionTitleStyle}>
+              Built-in columns
+            </h3>
+          </div>
+          <p style={subsectionHintStyle}>
+            Standard, pre-defined volunteer table columns from the database.
           </p>
           <div>
-            {customRows.map((row) => (
+            {builtInRows.map((row) => (
               <ColumnToggleRow
                 key={row.id}
                 row={row}
                 isHidden={hidden.has(row.id)}
-                disabled={saving}
+                disabled={busy}
                 onToggle={() => toggle(row.id)}
               />
             ))}
           </div>
         </div>
-      )}
 
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "flex-end",
-          gap: "0.75rem",
-          marginTop: "1rem",
-          padding: "0.75rem 1rem",
-          backgroundColor: isDirty ? "#fffbeb" : "#f9fafb",
-          border: isDirty ? "1px solid #fde68a" : "1px solid #e5e5e5",
-          borderRadius: "8px",
-        }}
+        <div
+          style={{
+            borderTop: "1px solid #f3f4f6",
+            paddingTop: "1.25rem",
+            marginTop: "0.25rem",
+          }}
+        >
+          <div style={subsectionHeadingRow}>
+            <h3 id="custom-hide-heading" style={subsectionTitleStyle}>
+              Custom columns
+            </h3>
+          </div>
+          <p style={subsectionHintStyle}>
+            Columns created by admin users. Hiding does not delete stored data.
+          </p>
+          {customRows.length === 0 ? (
+            <p
+              style={{
+                fontSize: "0.875rem",
+                color: "#737373",
+                margin: "0 0 0.5rem",
+              }}
+            >
+              No custom columns yet. Create one in the panel below; it will
+              appear here for visibility control.
+            </p>
+          ) : (
+            <div>
+              {customRows.map((row) => (
+                <ColumnToggleRow
+                  key={row.id}
+                  row={row}
+                  isHidden={hidden.has(row.id)}
+                  disabled={busy}
+                  onToggle={() => toggle(row.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        sectionId="create-column-heading"
+        title="Create custom column"
+        description="Adds a new column to the volunteers table for all signed-in users. Adding a column makes it visible for everyone, not just you."
+        icon={
+          <Plus
+            style={{
+              width: 18,
+              height: 18,
+              color: "var(--trcc-purple, #7c3aed)",
+            }}
+            aria-hidden
+          />
+        }
+        footer={
+          <div style={panelFooterRowStyle}>
+            <span
+              style={{
+                marginRight: "auto",
+                fontSize: "0.8125rem",
+                color: "#737373",
+              }}
+            >
+              Columns are created immediately when you click the button.
+            </span>
+            <button
+              type="button"
+              onClick={() => void handleCreateCustomColumn()}
+              disabled={busy}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "0.5rem",
+                padding: "0.5rem 1rem",
+                borderRadius: "6px",
+                border: "none",
+                backgroundColor: busy
+                  ? "#d4d4d4"
+                  : "var(--trcc-purple, #7c3aed)",
+                color: "#fff",
+                fontWeight: 500,
+                fontSize: "0.875rem",
+                cursor: busy ? "not-allowed" : "pointer",
+              }}
+            >
+              {creating ? (
+                <>
+                  <Loader2
+                    style={{ width: 16, height: 16 }}
+                    className="animate-spin"
+                    aria-hidden
+                  />
+                  Creating…
+                </>
+              ) : (
+                "Create column"
+              )}
+            </button>
+          </div>
+        }
       >
-        <span
+        <div
           style={{
-            marginRight: "auto",
-            fontSize: "0.875rem",
-            color: isDirty ? "#92400e" : "#525252",
-            fontWeight: isDirty ? 500 : 400,
+            display: "grid",
+            gap: "0.75rem",
+            maxWidth: "28rem",
           }}
         >
-          {hiddenCount === 0 ? (
-            <span style={{ color: "#15803d" }}>
-              All listed columns visible.
-            </span>
-          ) : (
+          <div>
+            <label htmlFor="table-mgmt-new-name" style={fieldLabelStyle}>
+              Column name
+            </label>
+            <input
+              id="table-mgmt-new-name"
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              disabled={busy}
+              placeholder="e.g. T-shirt size"
+              style={fieldControlStyle}
+            />
+          </div>
+          <div>
+            <label htmlFor="table-mgmt-new-type" style={fieldLabelStyle}>
+              Data type
+            </label>
+            <select
+              id="table-mgmt-new-type"
+              value={newType}
+              onChange={(e) =>
+                setNewType(e.target.value as NewCustomColumnInput["data_type"])
+              }
+              disabled={busy}
+              style={fieldControlStyle}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="boolean">Yes / No</option>
+              <option value="tag">Tag</option>
+            </select>
+          </div>
+          {newType === "tag" && (
             <>
-              <span style={{ fontWeight: 600, color: "#171717" }}>
-                {hiddenCount}
-              </span>{" "}
-              column{hiddenCount === 1 ? "" : "s"} hidden for everyone
+              <div>
+                <label htmlFor="table-mgmt-tag-options" style={fieldLabelStyle}>
+                  Tag options (optional)
+                </label>
+                <textarea
+                  id="table-mgmt-tag-options"
+                  value={tagOptionsRaw}
+                  onChange={(e) => setTagOptionsRaw(e.target.value)}
+                  disabled={busy}
+                  placeholder="Comma or newline separated"
+                  rows={2}
+                  style={{ ...fieldControlStyle, resize: "vertical" }}
+                />
+              </div>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                  fontSize: "0.875rem",
+                  color: "#404040",
+                  cursor: busy ? "not-allowed" : "pointer",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={tagMulti}
+                  disabled={busy}
+                  onChange={(e) => setTagMulti(e.target.checked)}
+                />
+                Allow multiple tags
+              </label>
             </>
           )}
-          {isDirty && (
-            <span style={{ marginLeft: "0.5rem", color: "#b45309" }}>
-              · Unsaved changes
-            </span>
-          )}
-        </span>
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={saving || !isDirty}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "0.5rem",
-            padding: "0.5rem 1rem",
-            borderRadius: "6px",
-            backgroundColor:
-              saving || !isDirty ? "#d4d4d4" : "var(--trcc-purple, #7c3aed)",
-            color: "#fff",
-            border: "none",
-            fontWeight: 500,
-            cursor: saving || !isDirty ? "not-allowed" : "pointer",
-            fontSize: "0.875rem",
-          }}
-        >
-          {saving ? (
-            <>
-              <Loader2
-                style={{ width: 16, height: 16 }}
-                className="animate-spin"
-                aria-hidden
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        sectionId="delete-column-heading"
+        title="Remove custom columns"
+        description={
+          <>
+            Permanently deletes a column and <strong>all</strong> values stored
+            for that field on every volunteer. Built-in columns cannot be
+            removed here.
+          </>
+        }
+        iconFrameStyle={{ backgroundColor: "#ffe4e6" }}
+        icon={
+          <Trash2
+            style={{ width: 18, height: 18, color: "#e11d48" }}
+            aria-hidden
+          />
+        }
+      >
+        {customColumns.length === 0 ? (
+          <p
+            style={{
+              fontSize: "0.875rem",
+              color: "#737373",
+              margin: 0,
+              lineHeight: 1.5,
+            }}
+          >
+            There are no custom columns to remove.
+          </p>
+        ) : (
+          <div>
+            {customColumns.map((c) => (
+              <CustomColumnDeleteRow
+                key={c.id}
+                column={c}
+                disabled={busy}
+                onRequestRemove={() => setConfirmDeleteColumn(c)}
               />
-              Saving…
-            </>
-          ) : (
-            "Save changes"
-          )}
-        </button>
-      </div>
+            ))}
+          </div>
+        )}
+      </SettingsSection>
+
+      {confirmDeleteColumn && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 200,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1rem",
+            backgroundColor: "rgba(0, 0, 0, 0.45)",
+          }}
+          role="presentation"
+          onClick={() => {
+            if (!deleting) setConfirmDeleteColumn(null);
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-col-confirm-title"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && !deleting) setConfirmDeleteColumn(null);
+            }}
+            style={{
+              width: "100%",
+              maxWidth: "26rem",
+              padding: "1.25rem",
+              borderRadius: "10px",
+              backgroundColor: "#fff",
+              borderWidth: "1px",
+              borderStyle: "solid",
+              borderColor: "#e5e5e5",
+              boxShadow: "0 8px 30px rgba(0, 0, 0, 0.12)",
+            }}
+          >
+            <h3
+              id="delete-col-confirm-title"
+              style={{
+                fontSize: "1rem",
+                fontWeight: 600,
+                color: "#171717",
+                margin: "0 0 0.5rem",
+              }}
+            >
+              Remove column?
+            </h3>
+            <p
+              style={{
+                fontSize: "0.875rem",
+                color: "#525252",
+                lineHeight: 1.5,
+                margin: "0 0 0.75rem",
+              }}
+            >
+              <strong>{confirmDeleteColumn.name}</strong> (
+              {tableIdForCustomColumn(confirmDeleteColumn.column_key)}) and all
+              of its data will be removed from the database. This cannot be
+              undone.
+            </p>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: "0.5rem",
+                flexWrap: "wrap",
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setConfirmDeleteColumn(null)}
+                disabled={deleting}
+                style={{
+                  padding: "0.5rem 1rem",
+                  borderRadius: "6px",
+                  borderWidth: "1px",
+                  borderStyle: "solid",
+                  borderColor: "#d4d4d4",
+                  backgroundColor: "#fff",
+                  fontSize: "0.875rem",
+                  fontWeight: 500,
+                  color: "#404040",
+                  cursor: deleting ? "not-allowed" : "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConfirmDeleteColumn()}
+                disabled={deleting}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                  padding: "0.5rem 1rem",
+                  borderRadius: "6px",
+                  border: "none",
+                  backgroundColor: deleting ? "#fca5a5" : "#dc2626",
+                  color: "#fff",
+                  fontSize: "0.875rem",
+                  fontWeight: 500,
+                  cursor: deleting ? "not-allowed" : "pointer",
+                }}
+              >
+                {deleting ? (
+                  <>
+                    <Loader2
+                      style={{ width: 16, height: 16 }}
+                      className="animate-spin"
+                      aria-hidden
+                    />
+                    Removing…
+                  </>
+                ) : (
+                  "Remove permanently"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/settings/TableManagementContent.tsx
+++ b/src/components/settings/TableManagementContent.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  COLUMNS_CONFIG,
+  tableIdForCustomColumn,
+} from "@/components/volunteers/volunteerColumns";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
+import { saveVolunteerTableGlobalSettingsAction } from "@/lib/api/actions";
+import {
+  NON_HIDEABLE_COLUMN_IDS,
+  sanitizeHiddenColumnIds,
+} from "@/lib/volunteerTable/columnVisibility";
+
+type Row = { id: string; label: string };
+
+const NON_HIDEABLE_SET = new Set(NON_HIDEABLE_COLUMN_IDS);
+
+export function TableManagementContent({
+  initialAdminHidden,
+  customColumns,
+}: {
+  initialAdminHidden: string[];
+  customColumns: CustomColumnRow[];
+}): React.JSX.Element {
+  const rows: Row[] = useMemo(() => {
+    const builtIn: Row[] = COLUMNS_CONFIG.filter(
+      (c) => !NON_HIDEABLE_SET.has(String(c.id))
+    ).map((c) => ({
+      id: String(c.id),
+      label: c.label,
+    }));
+    const custom: Row[] = customColumns.map((c) => ({
+      id: tableIdForCustomColumn(c.column_key),
+      label: c.name,
+    }));
+    return [...builtIn, ...custom];
+  }, [customColumns]);
+
+  const [hidden, setHidden] = useState<Set<string>>(
+    () => new Set(sanitizeHiddenColumnIds(initialAdminHidden))
+  );
+  const [saving, setSaving] = useState(false);
+
+  const toggle = (id: string): void => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSave = async (): Promise<void> => {
+    setSaving(true);
+    try {
+      const res = await saveVolunteerTableGlobalSettingsAction([...hidden]);
+      if (!res.success) {
+        toast.error(res.error ?? "Could not save");
+        return;
+      }
+      toast.success("Table visibility saved");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: "40rem" }}>
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          color: "#171717",
+          marginBottom: "0.5rem",
+        }}
+      >
+        Table Management
+      </h1>
+      <p style={{ color: "#525252", lineHeight: 1.5, marginBottom: "0.75rem" }}>
+        Choose which volunteer table columns are hidden for <strong>all</strong>{" "}
+        signed-in users (including other admins and staff). Personal column
+        choices in Manage columns still apply on top of this list.
+      </p>
+      <p
+        style={{
+          color: "#737373",
+          fontSize: "0.8125rem",
+          lineHeight: 1.5,
+          marginBottom: "1.25rem",
+        }}
+      >
+        Volunteer ID and Opt-in communication always stay visible and cannot be
+        hidden here.
+      </p>
+      <ul
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+        }}
+      >
+        {rows.map((row) => (
+          <li
+            key={row.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.75rem",
+              padding: "0.5rem 0.75rem",
+              border: "1px solid #e5e7eb",
+              borderRadius: "8px",
+              backgroundColor: "#fafafa",
+            }}
+          >
+            <input
+              id={`hide-col-${row.id}`}
+              type="checkbox"
+              checked={hidden.has(row.id)}
+              onChange={() => toggle(row.id)}
+              disabled={saving}
+            />
+            <label
+              htmlFor={`hide-col-${row.id}`}
+              style={{ cursor: saving ? "default" : "pointer", flex: 1 }}
+            >
+              <span style={{ fontWeight: 500, color: "#171717" }}>
+                {row.label}
+              </span>
+              <span
+                style={{
+                  display: "block",
+                  fontSize: "0.75rem",
+                  color: "#737373",
+                  fontFamily: "ui-monospace, monospace",
+                }}
+              >
+                {row.id}
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={() => void handleSave()}
+        disabled={saving}
+        style={{
+          marginTop: "1.25rem",
+          padding: "0.5rem 1.25rem",
+          borderRadius: "8px",
+          border: "none",
+          backgroundColor: "#1c1917",
+          color: "#fff",
+          fontWeight: 600,
+          fontSize: "0.875rem",
+          cursor: saving ? "not-allowed" : "pointer",
+          opacity: saving ? 0.7 : 1,
+        }}
+      >
+        {saving ? "Saving…" : "Save visibility"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/settings/TableManagementContent.tsx
+++ b/src/components/settings/TableManagementContent.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
+import { Columns3, Info, LayoutList, Loader2, Sparkles } from "lucide-react";
 import {
   COLUMNS_CONFIG,
   tableIdForCustomColumn,
@@ -17,6 +18,129 @@ type Row = { id: string; label: string };
 
 const NON_HIDEABLE_SET = new Set(NON_HIDEABLE_COLUMN_IDS);
 
+function serializeHidden(s: Set<string>): string {
+  return JSON.stringify([...s].sort());
+}
+
+const rowBaseStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "1rem",
+  padding: "0.75rem 1rem",
+  marginBottom: "0.5rem",
+  borderRadius: "6px",
+  border: "1px solid #e5e5e5",
+  backgroundColor: "#fff",
+};
+
+function ColumnToggleRow({
+  row,
+  isHidden,
+  disabled,
+  onToggle,
+}: {
+  row: Row;
+  isHidden: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <div
+      style={{
+        ...rowBaseStyle,
+        ...(isHidden
+          ? {
+              borderColor: "#e9d5ff",
+              backgroundColor: "#faf5ff",
+            }
+          : {}),
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <p
+          style={{
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            color: "#171717",
+            margin: 0,
+          }}
+        >
+          {row.label}
+        </p>
+        <p
+          style={{
+            margin: "0.25rem 0 0",
+            fontFamily: "ui-monospace, monospace",
+            fontSize: "0.6875rem",
+            color: "#737373",
+            wordBreak: "break-all",
+          }}
+        >
+          {row.id}
+        </p>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            fontSize: "0.75rem",
+            fontWeight: 500,
+            color: isHidden ? "#6b21a8" : "#15803d",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {isHidden ? "Hidden for everyone" : "Visible to everyone"}
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isHidden}
+          aria-label={`${isHidden ? "Show" : "Hide"} ${row.label} for all users`}
+          disabled={disabled}
+          onClick={onToggle}
+          style={{
+            position: "relative",
+            display: "inline-flex",
+            height: "28px",
+            width: "44px",
+            flexShrink: 0,
+            cursor: disabled ? "not-allowed" : "pointer",
+            borderRadius: "9999px",
+            border: "2px solid transparent",
+            backgroundColor: isHidden
+              ? "var(--trcc-purple, #7c3aed)"
+              : "#e5e5e5",
+            opacity: disabled ? 0.5 : 1,
+            transition: "background-color 0.2s ease",
+          }}
+        >
+          <span
+            style={{
+              pointerEvents: "none",
+              display: "inline-block",
+              height: "24px",
+              width: "24px",
+              borderRadius: "9999px",
+              backgroundColor: "#fff",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.1)",
+              transform: isHidden ? "translateX(16px)" : "translateX(2px)",
+              transition: "transform 0.2s ease",
+            }}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function TableManagementContent({
   initialAdminHidden,
   customColumns,
@@ -24,24 +148,41 @@ export function TableManagementContent({
   initialAdminHidden: string[];
   customColumns: CustomColumnRow[];
 }): React.JSX.Element {
-  const rows: Row[] = useMemo(() => {
-    const builtIn: Row[] = COLUMNS_CONFIG.filter(
-      (c) => !NON_HIDEABLE_SET.has(String(c.id))
-    ).map((c) => ({
-      id: String(c.id),
-      label: c.label,
-    }));
-    const custom: Row[] = customColumns.map((c) => ({
-      id: tableIdForCustomColumn(c.column_key),
-      label: c.name,
-    }));
-    return [...builtIn, ...custom];
-  }, [customColumns]);
+  const builtInRows: Row[] = useMemo(
+    () =>
+      COLUMNS_CONFIG.filter((c) => !NON_HIDEABLE_SET.has(String(c.id))).map(
+        (c) => ({
+          id: String(c.id),
+          label: c.label,
+        })
+      ),
+    []
+  );
 
-  const [hidden, setHidden] = useState<Set<string>>(
-    () => new Set(sanitizeHiddenColumnIds(initialAdminHidden))
+  const customRows: Row[] = useMemo(
+    () =>
+      customColumns.map((c) => ({
+        id: tableIdForCustomColumn(c.column_key),
+        label: c.name,
+      })),
+    [customColumns]
+  );
+
+  const [hidden, setHidden] = useState<Set<string>>(() => {
+    return new Set(sanitizeHiddenColumnIds(initialAdminHidden));
+  });
+  const [savedSignature, setSavedSignature] = useState(() =>
+    serializeHidden(new Set(sanitizeHiddenColumnIds(initialAdminHidden)))
   );
   const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const next = new Set(sanitizeHiddenColumnIds(initialAdminHidden));
+    setHidden(next);
+    setSavedSignature(serializeHidden(next));
+  }, [initialAdminHidden]);
+
+  const isDirty = serializeHidden(hidden) !== savedSignature;
 
   const toggle = (id: string): void => {
     setHidden((prev) => {
@@ -52,6 +193,8 @@ export function TableManagementContent({
     });
   };
 
+  const hiddenCount = hidden.size;
+
   const handleSave = async (): Promise<void> => {
     setSaving(true);
     try {
@@ -60,110 +203,266 @@ export function TableManagementContent({
         toast.error(res.error ?? "Could not save");
         return;
       }
-      toast.success("Table visibility saved");
+      setSavedSignature(serializeHidden(hidden));
+      toast.success("Volunteers table visibility updated");
     } finally {
       setSaving(false);
     }
   };
 
+  const sectionHeadingStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    marginBottom: "0.5rem",
+  };
+
+  const sectionTitleStyle: React.CSSProperties = {
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "#404040",
+    margin: 0,
+  };
+
+  const sectionHintStyle: React.CSSProperties = {
+    fontSize: "0.75rem",
+    color: "#737373",
+    margin: "0 0 0.75rem",
+    lineHeight: 1.5,
+    maxWidth: "40rem",
+  };
+
   return (
-    <div style={{ maxWidth: "40rem" }}>
-      <h1
+    <div>
+      <div
         style={{
-          fontSize: "1.5rem",
-          fontWeight: 700,
-          color: "#171717",
-          marginBottom: "0.5rem",
-        }}
-      >
-        Table Management
-      </h1>
-      <p style={{ color: "#525252", lineHeight: 1.5, marginBottom: "0.75rem" }}>
-        Choose which volunteer table columns are hidden for <strong>all</strong>{" "}
-        signed-in users (including other admins and staff). Personal column
-        choices in Manage columns still apply on top of this list.
-      </p>
-      <p
-        style={{
-          color: "#737373",
-          fontSize: "0.8125rem",
-          lineHeight: 1.5,
-          marginBottom: "1.25rem",
-        }}
-      >
-        Volunteer ID and Opt-in communication always stay visible and cannot be
-        hidden here.
-      </p>
-      <ul
-        style={{
-          listStyle: "none",
-          padding: 0,
-          margin: 0,
           display: "flex",
-          flexDirection: "column",
-          gap: "0.5rem",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: "1.5rem",
+          paddingBottom: "1rem",
+          borderBottom: "1px solid #e5e5e5",
         }}
       >
-        {rows.map((row) => (
-          <li
-            key={row.id}
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <div
             style={{
+              width: 40,
+              height: 40,
+              borderRadius: "10px",
+              backgroundColor: "var(--trcc-light-purple, #ede9fe)",
               display: "flex",
               alignItems: "center",
-              gap: "0.75rem",
-              padding: "0.5rem 0.75rem",
-              border: "1px solid #e5e7eb",
-              borderRadius: "8px",
-              backgroundColor: "#fafafa",
+              justifyContent: "center",
+              flexShrink: 0,
             }}
           >
-            <input
-              id={`hide-col-${row.id}`}
-              type="checkbox"
-              checked={hidden.has(row.id)}
-              onChange={() => toggle(row.id)}
-              disabled={saving}
+            <Columns3
+              style={{
+                width: 20,
+                height: 20,
+                color: "var(--trcc-purple, #7c3aed)",
+              }}
+              aria-hidden
             />
-            <label
-              htmlFor={`hide-col-${row.id}`}
-              style={{ cursor: saving ? "default" : "pointer", flex: 1 }}
+          </div>
+          <div>
+            <h1
+              style={{
+                fontSize: "1.25rem",
+                fontWeight: 700,
+                color: "#171717",
+                margin: 0,
+              }}
             >
-              <span style={{ fontWeight: 500, color: "#171717" }}>
-                {row.label}
+              Table Management
+            </h1>
+            <p
+              style={{
+                fontSize: "0.8125rem",
+                color: "#737373",
+                margin: "0.25rem 0 0",
+                lineHeight: 1.5,
+                maxWidth: "36rem",
+              }}
+            >
+              <span style={{ color: "#404040", fontWeight: 600 }}>
+                {builtInRows.length + customRows.length} column
+                {builtInRows.length + customRows.length === 1 ? "" : "s"}
               </span>
-              <span
-                style={{
-                  display: "block",
-                  fontSize: "0.75rem",
-                  color: "#737373",
-                  fontFamily: "ui-monospace, monospace",
-                }}
-              >
-                {row.id}
-              </span>
-            </label>
-          </li>
-        ))}
-      </ul>
-      <button
-        type="button"
-        onClick={() => void handleSave()}
-        disabled={saving}
+              <span style={{ color: "#a3a3a3" }}> · </span>
+              Choose which columns are hidden for every signed-in user on the
+              volunteers dashboard. Personal “Manage columns” settings can hide
+              additional columns on top of this list.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        role="note"
         style={{
-          marginTop: "1.25rem",
-          padding: "0.5rem 1.25rem",
-          borderRadius: "8px",
-          border: "none",
-          backgroundColor: "#1c1917",
-          color: "#fff",
-          fontWeight: 600,
+          display: "flex",
+          gap: "0.5rem",
+          padding: "0.75rem 1rem",
+          marginBottom: "1.5rem",
+          backgroundColor: "#fffbeb",
+          border: "1px solid #fde68a",
+          borderRadius: "6px",
           fontSize: "0.875rem",
-          cursor: saving ? "not-allowed" : "pointer",
-          opacity: saving ? 0.7 : 1,
+          color: "#92400e",
+          lineHeight: 1.5,
         }}
       >
-        {saving ? "Saving…" : "Save visibility"}
-      </button>
+        <Info
+          style={{
+            width: 18,
+            height: 18,
+            flexShrink: 0,
+            marginTop: 2,
+            color: "#b45309",
+          }}
+          aria-hidden
+        />
+        <p style={{ margin: 0 }}>
+          <span style={{ fontWeight: 600 }}>Always visible:</span> Volunteer ID
+          and Opt-in communication cannot be hidden here or in personal column
+          settings.
+        </p>
+      </div>
+
+      <div style={{ marginBottom: "2rem" }}>
+        <div style={sectionHeadingStyle}>
+          <LayoutList
+            style={{ width: 16, height: 16, color: "#737373" }}
+            aria-hidden
+          />
+          <h2 id="builtin-heading" style={sectionTitleStyle}>
+            Built-in columns
+          </h2>
+        </div>
+        <p style={sectionHintStyle}>
+          Standard volunteer fields. Turn the switch on to hide a column for the
+          whole team.
+        </p>
+        <div>
+          {builtInRows.map((row) => (
+            <ColumnToggleRow
+              key={row.id}
+              row={row}
+              isHidden={hidden.has(row.id)}
+              disabled={saving}
+              onToggle={() => toggle(row.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {customRows.length > 0 && (
+        <div style={{ marginBottom: "2rem" }}>
+          <div style={sectionHeadingStyle}>
+            <Sparkles
+              style={{
+                width: 16,
+                height: 16,
+                color: "var(--trcc-purple, #7c3aed)",
+              }}
+              aria-hidden
+            />
+            <h2 id="custom-heading" style={sectionTitleStyle}>
+              Custom columns
+            </h2>
+          </div>
+          <p style={sectionHintStyle}>
+            Fields your organization added in Manage columns. You can hide them
+            here without deleting stored data.
+          </p>
+          <div>
+            {customRows.map((row) => (
+              <ColumnToggleRow
+                key={row.id}
+                row={row}
+                isHidden={hidden.has(row.id)}
+                disabled={saving}
+                onToggle={() => toggle(row.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          gap: "0.75rem",
+          marginTop: "1rem",
+          padding: "0.75rem 1rem",
+          backgroundColor: isDirty ? "#fffbeb" : "#f9fafb",
+          border: isDirty ? "1px solid #fde68a" : "1px solid #e5e5e5",
+          borderRadius: "8px",
+        }}
+      >
+        <span
+          style={{
+            marginRight: "auto",
+            fontSize: "0.875rem",
+            color: isDirty ? "#92400e" : "#525252",
+            fontWeight: isDirty ? 500 : 400,
+          }}
+        >
+          {hiddenCount === 0 ? (
+            <span style={{ color: "#15803d" }}>
+              All listed columns visible.
+            </span>
+          ) : (
+            <>
+              <span style={{ fontWeight: 600, color: "#171717" }}>
+                {hiddenCount}
+              </span>{" "}
+              column{hiddenCount === 1 ? "" : "s"} hidden for everyone
+            </>
+          )}
+          {isDirty && (
+            <span style={{ marginLeft: "0.5rem", color: "#b45309" }}>
+              · Unsaved changes
+            </span>
+          )}
+        </span>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={saving || !isDirty}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            padding: "0.5rem 1rem",
+            borderRadius: "6px",
+            backgroundColor:
+              saving || !isDirty ? "#d4d4d4" : "var(--trcc-purple, #7c3aed)",
+            color: "#fff",
+            border: "none",
+            fontWeight: 500,
+            cursor: saving || !isDirty ? "not-allowed" : "pointer",
+            fontSize: "0.875rem",
+          }}
+        >
+          {saving ? (
+            <>
+              <Loader2
+                style={{ width: 16, height: 16 }}
+                className="animate-spin"
+                aria-hidden
+              />
+              Saving…
+            </>
+          ) : (
+            "Save changes"
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/volunteers/AddVolunteerModal.tsx
+++ b/src/components/volunteers/AddVolunteerModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useId } from "react";
+import React, { useState, useEffect, useCallback, useId, useMemo } from "react";
 import { X, UserPlus } from "lucide-react";
 import clsx from "clsx";
 import { createVolunteerAction } from "@/lib/api/actions";
@@ -10,6 +10,7 @@ import type { Json } from "@/lib/client/supabase/types";
 import {
   customColumnIcon,
   NEW_VOLUNTEER_FORM_COLUMNS,
+  tableIdForCustomColumn,
 } from "./volunteerColumns";
 import type { Volunteer } from "./types";
 import { VolunteerTag } from "./VolunteerTag";
@@ -31,6 +32,8 @@ interface AddVolunteerModalProps {
   onSuccess: () => void;
   optionsData?: Record<string, string[]>;
   customColumns?: CustomColumnRow[];
+  /** Table Management → globally hidden column ids (same as the volunteers table). */
+  globalHiddenColumnIds?: string[];
 }
 
 const FORM_SECTIONS: {
@@ -362,8 +365,29 @@ export const AddVolunteerModal = ({
   onSuccess,
   optionsData = {},
   customColumns = [],
+  globalHiddenColumnIds = [],
 }: AddVolunteerModalProps): React.JSX.Element | null => {
   const currentYear = new Date().getFullYear();
+
+  const globalHiddenSet = useMemo(
+    () => new Set(globalHiddenColumnIds),
+    [globalHiddenColumnIds]
+  );
+
+  /** Custom columns visible on the table (excludes org-wide hidden). New columns from the parent list appear here automatically. */
+  const visibleCustomColumns = useMemo(
+    () =>
+      customColumns.filter(
+        (c) => !globalHiddenSet.has(tableIdForCustomColumn(c.column_key))
+      ),
+    [customColumns, globalHiddenSet]
+  );
+
+  const isBuiltInHiddenOnTable = useCallback(
+    (columnId: keyof Volunteer): boolean =>
+      globalHiddenSet.has(String(columnId)),
+    [globalHiddenSet]
+  );
 
   const [nameOrg, setNameOrg] = useState("");
   const [email, setEmail] = useState("");
@@ -450,7 +474,7 @@ export const AddVolunteerModal = ({
       })),
     ].filter((r) => r.name.length > 0);
 
-    for (const cc of customColumns) {
+    for (const cc of visibleCustomColumns) {
       if (cc.data_type !== "number") continue;
       const raw = customForm[cc.column_key];
       if (raw === undefined || raw === null || String(raw).trim() === "")
@@ -463,7 +487,7 @@ export const AddVolunteerModal = ({
     }
 
     const custom_data: Record<string, unknown> = {};
-    for (const cc of customColumns) {
+    for (const cc of visibleCustomColumns) {
       const raw = customForm[cc.column_key];
       if (raw === undefined || raw === null) continue;
       switch (cc.data_type) {
@@ -642,6 +666,11 @@ export const AddVolunteerModal = ({
   };
 
   if (!isOpen) return null;
+
+  /** Full name is always collected here so new volunteers can be created even if that column is hidden on the table. */
+  const profileTailIds = (
+    ["pseudonym", "pronouns", "email", "phone"] as const
+  ).filter((fid) => !isBuiltInHiddenOnTable(fid));
 
   const renderField = (
     col: (typeof NEW_VOLUNTEER_FORM_COLUMNS)[number]
@@ -861,53 +890,55 @@ export const AddVolunteerModal = ({
                   : {})}
               >
                 <div className="grid gap-4 sm:grid-cols-2">
-                  {(["name_org"] as const).map((fid) => {
+                  {((): React.JSX.Element | null => {
+                    const nameCol = NEW_VOLUNTEER_FORM_COLUMNS.find(
+                      (c) => c.id === "name_org"
+                    );
+                    return nameCol ? (
+                      <div key="name_org" className="sm:col-span-2">
+                        {renderField(nameCol)}
+                      </div>
+                    ) : null;
+                  })()}
+                  {profileTailIds.map((fid) => {
                     const col = NEW_VOLUNTEER_FORM_COLUMNS.find(
                       (c) => c.id === fid
                     );
-                    return col ? (
-                      <div key={fid} className="sm:col-span-2">
-                        {renderField(col)}
-                      </div>
-                    ) : null;
+                    return col ? <div key={fid}>{renderField(col)}</div> : null;
                   })}
-                  {(["pseudonym", "pronouns", "email", "phone"] as const).map(
-                    (fid) => {
-                      const col = NEW_VOLUNTEER_FORM_COLUMNS.find(
-                        (c) => c.id === fid
-                      );
-                      return col ? (
-                        <div key={fid}>{renderField(col)}</div>
-                      ) : null;
-                    }
-                  )}
                 </div>
               </SectionCard>
 
-              {FORM_SECTIONS.slice(1).map((section) => (
-                <SectionCard
-                  key={section.title}
-                  title={section.title}
-                  {...(section.description != null
-                    ? { description: section.description }
-                    : {})}
-                >
-                  {section.columnIds.map((columnId) => {
-                    const col = NEW_VOLUNTEER_FORM_COLUMNS.find(
-                      (c) => c.id === columnId
-                    );
-                    return col ? renderField(col) : null;
-                  })}
-                </SectionCard>
-              ))}
+              {FORM_SECTIONS.slice(1).map((section) => {
+                const visibleColumnIds = section.columnIds.filter(
+                  (columnId) => !isBuiltInHiddenOnTable(columnId)
+                );
+                if (visibleColumnIds.length === 0) return null;
+                return (
+                  <SectionCard
+                    key={section.title}
+                    title={section.title}
+                    {...(section.description != null
+                      ? { description: section.description }
+                      : {})}
+                  >
+                    {visibleColumnIds.map((columnId) => {
+                      const col = NEW_VOLUNTEER_FORM_COLUMNS.find(
+                        (c) => c.id === columnId
+                      );
+                      return col ? renderField(col) : null;
+                    })}
+                  </SectionCard>
+                );
+              })}
 
-              {customColumns.length > 0 ? (
+              {visibleCustomColumns.length > 0 ? (
                 <SectionCard
                   title="Custom fields"
                   description="Optional values stored on the volunteer record. You can change them later in the table."
                 >
                   <div className="grid gap-4 sm:grid-cols-2">
-                    {customColumns.map((cc) => (
+                    {visibleCustomColumns.map((cc) => (
                       <div
                         key={cc.column_key}
                         className={

--- a/src/components/volunteers/AddVolunteerModal.tsx
+++ b/src/components/volunteers/AddVolunteerModal.tsx
@@ -4,8 +4,13 @@ import React, { useState, useEffect, useCallback, useId } from "react";
 import { X, UserPlus } from "lucide-react";
 import clsx from "clsx";
 import { createVolunteerAction } from "@/lib/api/actions";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
 import type { CohortTerm } from "@/lib/api/createVolunteer";
-import { NEW_VOLUNTEER_FORM_COLUMNS } from "./volunteerColumns";
+import type { Json } from "@/lib/client/supabase/types";
+import {
+  customColumnIcon,
+  NEW_VOLUNTEER_FORM_COLUMNS,
+} from "./volunteerColumns";
 import type { Volunteer } from "./types";
 import { VolunteerTag } from "./VolunteerTag";
 import { OPT_IN_OPTIONS } from "./utils";
@@ -25,6 +30,7 @@ interface AddVolunteerModalProps {
   onClose: () => void;
   onSuccess: () => void;
   optionsData?: Record<string, string[]>;
+  customColumns?: CustomColumnRow[];
 }
 
 const FORM_SECTIONS: {
@@ -111,6 +117,45 @@ function FieldLabel({
         {required ? <span className="text-red-500 font-normal"> *</span> : null}
       </span>
     </label>
+  );
+}
+
+function SingleTagField({
+  label,
+  icon: Icon,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  icon: React.ElementType;
+  value: string;
+  onChange: (next: string) => void;
+  options: string[];
+}): React.JSX.Element {
+  const datalistId = useId();
+  const suggestionOptions = [...new Set(options)].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  return (
+    <div className="flex flex-col gap-2">
+      <FieldLabel icon={Icon}>{label}</FieldLabel>
+      <input
+        type="text"
+        className={inputClass}
+        list={suggestionOptions.length > 0 ? datalistId : undefined}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Optional — type a new tag or pick a suggestion"
+      />
+      {suggestionOptions.length > 0 ? (
+        <datalist id={datalistId}>
+          {suggestionOptions.map((o) => (
+            <option key={o} value={o} />
+          ))}
+        </datalist>
+      ) : null}
+    </div>
   );
 }
 
@@ -316,6 +361,7 @@ export const AddVolunteerModal = ({
   onClose,
   onSuccess,
   optionsData = {},
+  customColumns = [],
 }: AddVolunteerModalProps): React.JSX.Element | null => {
   const currentYear = new Date().getFullYear();
 
@@ -330,6 +376,7 @@ export const AddVolunteerModal = ({
   const [priorRoles, setPriorRoles] = useState<string[]>([]);
   const [futureRoles, setFutureRoles] = useState<string[]>([]);
   const [cohortRows, setCohortRows] = useState<CohortFormRow[]>([]);
+  const [customForm, setCustomForm] = useState<Record<string, unknown>>({});
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -352,6 +399,7 @@ export const AddVolunteerModal = ({
     setPriorRoles([]);
     setFutureRoles([]);
     setCohortRows([]);
+    setCustomForm({});
     setError(null);
   }, []);
 
@@ -402,6 +450,57 @@ export const AddVolunteerModal = ({
       })),
     ].filter((r) => r.name.length > 0);
 
+    for (const cc of customColumns) {
+      if (cc.data_type !== "number") continue;
+      const raw = customForm[cc.column_key];
+      if (raw === undefined || raw === null || String(raw).trim() === "")
+        continue;
+      const n = Number(String(raw).replace(/,/g, ""));
+      if (Number.isNaN(n)) {
+        setError(`Enter a valid number for “${cc.name}”, or leave it blank.`);
+        return;
+      }
+    }
+
+    const custom_data: Record<string, unknown> = {};
+    for (const cc of customColumns) {
+      const raw = customForm[cc.column_key];
+      if (raw === undefined || raw === null) continue;
+      switch (cc.data_type) {
+        case "text": {
+          const s = String(raw).trim();
+          if (s) custom_data[cc.column_key] = s;
+          break;
+        }
+        case "number": {
+          const t = String(raw).trim();
+          if (!t) break;
+          const n = Number(t.replace(/,/g, ""));
+          if (!Number.isNaN(n)) custom_data[cc.column_key] = n;
+          break;
+        }
+        case "boolean": {
+          if (typeof raw === "boolean") {
+            custom_data[cc.column_key] = raw;
+          }
+          break;
+        }
+        case "tag":
+          if (cc.is_multi && Array.isArray(raw)) {
+            const tags = raw
+              .map((x) => String(x).trim())
+              .filter((x) => x.length > 0);
+            if (tags.length > 0) custom_data[cc.column_key] = tags;
+          } else if (!cc.is_multi && typeof raw === "string") {
+            const s = raw.trim();
+            if (s) custom_data[cc.column_key] = s;
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
     setSubmitting(true);
     try {
       const result = await createVolunteerAction({
@@ -413,6 +512,9 @@ export const AddVolunteerModal = ({
           pseudonym: pseudonym.trim() || null,
           opt_in_communication: optInLabel === "Yes",
           notes: notes.trim() || null,
+          ...(Object.keys(custom_data).length > 0
+            ? { custom_data: custom_data as Json }
+            : {}),
         },
         roles,
         cohorts,
@@ -428,6 +530,115 @@ export const AddVolunteerModal = ({
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const renderCustomColumnEditor = (cc: CustomColumnRow): React.JSX.Element => {
+    const Icon = customColumnIcon(cc.data_type);
+    if (cc.data_type === "boolean") {
+      const raw = customForm[cc.column_key];
+      const sel = raw === true ? "Yes" : raw === false ? "No" : "";
+      return (
+        <div key={cc.column_key} className="flex flex-col gap-2">
+          <FieldLabel icon={Icon}>{cc.name}</FieldLabel>
+          <select
+            value={sel}
+            onChange={(e) => {
+              const v = e.target.value;
+              setCustomForm((prev) => ({
+                ...prev,
+                [cc.column_key]:
+                  v === "Yes" ? true : v === "No" ? false : undefined,
+              }));
+            }}
+            className={selectClass}
+          >
+            <option value="">—</option>
+            {OPT_IN_OPTIONS.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
+      );
+    }
+    if (cc.data_type === "number") {
+      const s = (customForm[cc.column_key] as string | undefined) ?? "";
+      return (
+        <div key={cc.column_key} className="flex flex-col gap-2">
+          <FieldLabel icon={Icon}>{cc.name}</FieldLabel>
+          <input
+            type="text"
+            inputMode="decimal"
+            value={s}
+            onChange={(e) =>
+              setCustomForm((prev) => ({
+                ...prev,
+                [cc.column_key]: e.target.value,
+              }))
+            }
+            className={inputClass}
+            placeholder="Optional"
+          />
+        </div>
+      );
+    }
+    if (cc.data_type === "text") {
+      const s = (customForm[cc.column_key] as string | undefined) ?? "";
+      return (
+        <div key={cc.column_key} className="flex flex-col gap-2">
+          <FieldLabel icon={Icon}>{cc.name}</FieldLabel>
+          <input
+            type="text"
+            value={s}
+            onChange={(e) =>
+              setCustomForm((prev) => ({
+                ...prev,
+                [cc.column_key]: e.target.value,
+              }))
+            }
+            className={inputClass}
+            placeholder="Optional"
+          />
+        </div>
+      );
+    }
+    if (cc.data_type === "tag" && cc.is_multi) {
+      const vals = (customForm[cc.column_key] as string[] | undefined) ?? [];
+      return (
+        <MultiRoleField
+          key={cc.column_key}
+          label={cc.name}
+          icon={Icon}
+          options={cc.tag_options ?? []}
+          values={vals}
+          onChange={(next) =>
+            setCustomForm((prev) => ({ ...prev, [cc.column_key]: next }))
+          }
+        />
+      );
+    }
+    if (cc.data_type === "tag" && !cc.is_multi) {
+      const s = (customForm[cc.column_key] as string | undefined) ?? "";
+      return (
+        <SingleTagField
+          key={cc.column_key}
+          label={cc.name}
+          icon={Icon}
+          value={s}
+          onChange={(next) =>
+            setCustomForm((prev) => ({ ...prev, [cc.column_key]: next }))
+          }
+          options={cc.tag_options ?? []}
+        />
+      );
+    }
+    return (
+      <div key={cc.column_key} className="flex flex-col gap-2">
+        <FieldLabel icon={Icon}>{cc.name}</FieldLabel>
+        <p className="text-xs text-gray-500">Unsupported column type.</p>
+      </div>
+    );
   };
 
   if (!isOpen) return null;
@@ -689,6 +900,28 @@ export const AddVolunteerModal = ({
                   })}
                 </SectionCard>
               ))}
+
+              {customColumns.length > 0 ? (
+                <SectionCard
+                  title="Custom fields"
+                  description="Optional values stored on the volunteer record. You can change them later in the table."
+                >
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {customColumns.map((cc) => (
+                      <div
+                        key={cc.column_key}
+                        className={
+                          cc.data_type === "tag" && cc.is_multi
+                            ? "sm:col-span-2"
+                            : ""
+                        }
+                      >
+                        {renderCustomColumnEditor(cc)}
+                      </div>
+                    ))}
+                  </div>
+                </SectionCard>
+              ) : null}
 
               {error ? (
                 <div

--- a/src/components/volunteers/ColumnChangeLogModal.tsx
+++ b/src/components/volunteers/ColumnChangeLogModal.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import clsx from "clsx";
+import { CheckCircle2, XCircle } from "lucide-react";
+
+export type ColumnChangeLogEntry = {
+  description: string;
+  success: boolean;
+  error?: string;
+};
+
+interface ColumnChangeLogModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  entries: ColumnChangeLogEntry[];
+}
+
+export const ColumnChangeLogModal = ({
+  isOpen,
+  onClose,
+  entries,
+}: ColumnChangeLogModalProps): React.JSX.Element | null => {
+  if (!isOpen) return null;
+
+  const ok = entries.filter((e) => e.success).length;
+  const total = entries.length;
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center p-4 bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="column-change-log-title"
+    >
+      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(80vh,520px)]">
+        <div className="px-4 py-3 border-b border-gray-100 shrink-0">
+          <h2
+            id="column-change-log-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Column changes
+          </h2>
+          <p className="text-sm text-gray-600 mt-0.5">
+            {ok} of {total} operation{total === 1 ? "" : "s"} succeeded
+          </p>
+        </div>
+        <ul className="overflow-y-auto flex-1 px-3 py-2 space-y-2 min-h-0">
+          {entries.map((e, i) => (
+            <li
+              key={i}
+              className="flex gap-2 rounded-lg border border-gray-100 bg-gray-50/80 px-3 py-2 text-sm"
+            >
+              {e.success ? (
+                <CheckCircle2
+                  className="h-5 w-5 shrink-0 text-green-600 mt-0.5"
+                  aria-hidden
+                />
+              ) : (
+                <XCircle
+                  className="h-5 w-5 shrink-0 text-red-600 mt-0.5"
+                  aria-hidden
+                />
+              )}
+              <div className="min-w-0">
+                <p className="font-medium text-gray-900">{e.description}</p>
+                {!e.success && e.error && (
+                  <p className="text-red-700 text-xs mt-1 break-words">
+                    {e.error}
+                  </p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="px-4 py-3 border-t border-gray-100 shrink-0 flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className={clsx(
+              "rounded-lg px-4 py-2 text-sm font-medium",
+              "bg-purple-600 text-white hover:bg-purple-700",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300"
+            )}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/volunteers/EditableCell.tsx
+++ b/src/components/volunteers/EditableCell.tsx
@@ -21,6 +21,8 @@ interface EditableCellProps {
   options?: string[];
   isMulti?: boolean;
   type?: "text" | "options" | "number" | "boolean";
+  /** When true (e.g. custom tag column with no preset list), new tags can be typed like roles/cohorts. */
+  allowAddTags?: boolean;
 }
 
 export const EditableCell = ({
@@ -29,6 +31,7 @@ export const EditableCell = ({
   options = [],
   isMulti = false,
   type = "text",
+  allowAddTags = false,
 }: EditableCellProps): React.JSX.Element => {
   const initialValue = info.getValue();
   const isNotes = info.column.id === "notes";
@@ -53,12 +56,11 @@ export const EditableCell = ({
   const numberInputRef = useRef<HTMLInputElement>(null);
   const draftTextRef = useRef("");
 
-  const allowAdd: boolean = [
-    "cohorts",
-    "prior_roles",
-    "current_roles",
-    "future_interests",
-  ].includes(info.column.id);
+  const allowAdd: boolean =
+    allowAddTags ||
+    ["cohorts", "prior_roles", "current_roles", "future_interests"].includes(
+      info.column.id
+    );
 
   /** Forces a fresh DOM subtree when toggling edit mode; avoids ghost nodes from contentEditable + imperative textContent. */
   const modeKey = isEditing ? "edit" : "view";

--- a/src/components/volunteers/EditableCell.tsx
+++ b/src/components/volunteers/EditableCell.tsx
@@ -20,7 +20,7 @@ interface EditableCellProps {
   onEdit: (rowId: number, colId: string, value: unknown) => void;
   options?: string[];
   isMulti?: boolean;
-  type?: "text" | "options";
+  type?: "text" | "options" | "number" | "boolean";
 }
 
 export const EditableCell = ({
@@ -50,6 +50,7 @@ export const EditableCell = ({
   const popoverRef = useRef<HTMLDivElement>(null);
   const cellRef = useRef<HTMLDivElement>(null);
   const inlineEditorRef = useRef<HTMLDivElement>(null);
+  const numberInputRef = useRef<HTMLInputElement>(null);
   const draftTextRef = useRef("");
 
   const allowAdd: boolean = [
@@ -63,7 +64,7 @@ export const EditableCell = ({
   const modeKey = isEditing ? "edit" : "view";
 
   useEffect(() => {
-    if (isEditing && type === "text") return;
+    if (isEditing && (type === "text" || type === "number")) return;
     setValue(initialValue);
   }, [initialValue, isEditing, type]);
 
@@ -89,6 +90,13 @@ export const EditableCell = ({
     if (type === "text") {
       const text = String(value ?? "");
       draftTextRef.current = text;
+    }
+    if (type === "number") {
+      setInputValue(
+        value === null || value === undefined || value === ""
+          ? ""
+          : String(value)
+      );
     }
     setIsEditing(true);
   };
@@ -131,12 +139,17 @@ export const EditableCell = ({
   );
 
   useEffect(() => {
-    if (!isEditing || type === "text") return;
+    if (!isEditing) return;
+    if (type !== "options" && type !== "number" && type !== "boolean") return;
 
     const handleOutsideInteraction = (e: Event): void => {
       const target = e.target as Node;
       if (popoverRef.current?.contains(target)) return;
       if (cellRef.current?.contains(target)) return;
+      if (type === "boolean") {
+        setIsEditing(false);
+        return;
+      }
       handleSave();
     };
 
@@ -166,7 +179,12 @@ export const EditableCell = ({
   }, [isEditing, type]);
 
   const handleDelete = useCallback((): void => {
-    const cleared = isMulti ? [] : type === "options" ? null : "";
+    let cleared: unknown;
+    if (isMulti) cleared = [];
+    else if (type === "options") cleared = null;
+    else if (type === "boolean") cleared = null;
+    else if (type === "number") cleared = null;
+    else cleared = "";
     setValue(cleared);
     onEdit(info.row.original.id, info.column.id, cleared);
   }, [isMulti, type, info.row.original.id, info.column.id, onEdit]);
@@ -323,6 +341,134 @@ export const EditableCell = ({
     );
   }
 
+  if (isEditing && type === "number") {
+    const commitNumber = (): void => {
+      const raw = inputValue.trim();
+      if (raw === "") {
+        setValue(null);
+        handleSave(null);
+        return;
+      }
+      const n = Number(raw);
+      if (!Number.isFinite(n)) {
+        toast.error("Enter a valid number");
+        return;
+      }
+      setValue(n);
+      handleSave(n);
+    };
+
+    return (
+      <div
+        key={modeKey}
+        ref={cellRef}
+        className="relative w-full h-full flex items-center min-h-6"
+      >
+        <div
+          ref={popoverRef}
+          data-volunteers-overlay
+          style={{
+            position: "fixed",
+            top: `${modalCoords.top}px`,
+            left: `${modalCoords.left}px`,
+            width: `${modalCoords.width}px`,
+            zIndex: 99999,
+          }}
+          className="bg-white rounded-xl shadow-xl border border-gray-100 p-3 flex flex-col gap-2"
+        >
+          <input
+            ref={numberInputRef}
+            type="number"
+            autoFocus
+            className="w-full border border-gray-200 rounded-md px-2 py-1.5 text-sm tabular-nums outline-none focus:ring-2 focus:ring-purple-300"
+            value={inputValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>): void =>
+              setInputValue(e.target.value)
+            }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>): void => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commitNumber();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setValue(initialValue);
+                setIsEditing(false);
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={commitNumber}
+            className="text-sm font-medium text-purple-700 hover:text-purple-900 py-1"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isEditing && type === "boolean") {
+    const setBool = (next: boolean | null): void => {
+      setValue(next);
+      onEdit(info.row.original.id, info.column.id, next);
+      setIsEditing(false);
+    };
+
+    return (
+      <div
+        key={modeKey}
+        ref={cellRef}
+        className="relative w-full h-full flex items-center min-h-6"
+      >
+        <div
+          ref={popoverRef}
+          data-volunteers-overlay
+          style={{
+            position: "fixed",
+            top: `${modalCoords.top}px`,
+            left: `${modalCoords.left}px`,
+            width: `${modalCoords.width}px`,
+            zIndex: 99999,
+          }}
+          className="bg-white rounded-xl shadow-xl border border-gray-100 p-3 flex flex-col gap-2"
+        >
+          <label className="flex items-center gap-2 cursor-pointer text-sm">
+            <input
+              type="radio"
+              name={`bool-${info.column.id}-${info.row.id}`}
+              checked={value === true}
+              onChange={() => setBool(true)}
+              className="rounded border-gray-300 text-purple-600"
+            />
+            Yes
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer text-sm">
+            <input
+              type="radio"
+              name={`bool-${info.column.id}-${info.row.id}`}
+              checked={value === false}
+              onChange={() => setBool(false)}
+              className="rounded border-gray-300 text-purple-600"
+            />
+            No
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-600">
+            <input
+              type="radio"
+              name={`bool-${info.column.id}-${info.row.id}`}
+              checked={value !== true && value !== false}
+              onChange={() => setBool(null)}
+              className="rounded border-gray-300 text-purple-600"
+            />
+            (empty)
+          </label>
+        </div>
+      </div>
+    );
+  }
+
   if (isEditing && type === "text") {
     const commitAndExit = (): void => {
       const text = (inlineEditorRef.current?.textContent ?? "").replace(
@@ -395,6 +541,15 @@ export const EditableCell = ({
   }
 
   const renderReadOnlyTags = (): React.ReactNode => {
+    if (type === "boolean") {
+      if (value === true) return <VolunteerTag label="Yes" />;
+      if (value === false) return <VolunteerTag label="No" />;
+      return "";
+    }
+    if (type === "number") {
+      if (value === null || value === undefined || value === "") return "";
+      return <span className="tabular-nums">{String(value)}</span>;
+    }
     if (type === "options") {
       if (Array.isArray(value)) {
         return (value as string[]).map((v, i) => (

--- a/src/components/volunteers/FilterBar.tsx
+++ b/src/components/volunteers/FilterBar.tsx
@@ -55,6 +55,26 @@ function shortcutPresetLabel(f: FilterTuple): string | null {
   return null;
 }
 
+function formatFilterChipLabel(
+  filter: FilterTuple,
+  colDef: FilterableColumnDesc | undefined
+): string {
+  if (!colDef) return filter.field;
+  if (
+    filter.numberRange &&
+    colDef.type === "number" &&
+    Array.isArray(filter.values) &&
+    filter.values.length >= 2
+  ) {
+    const low = String(filter.values[0] ?? "").trim();
+    const high = String(filter.values[1] ?? "").trim();
+    if (low !== "" && high !== "") return `${colDef.label} ${low}–${high}`;
+    if (low !== "") return `${colDef.label} ≥ ${low}`;
+    if (high !== "") return `${colDef.label} ≤ ${high}`;
+  }
+  return colDef.label;
+}
+
 type OptInWarningVariant = "remove" | "include-no";
 
 const VARIANT_CONTENT: Record<
@@ -364,7 +384,7 @@ export const FilterBar = ({
 
             return (
               <div
-                key={`${filter.field}-${filter.miniOp}-${filter.values.join("¦")}-${index}`}
+                key={`${filter.field}-${filter.miniOp}-${filter.values.join("¦")}-${filter.numberRange ? "r" : ""}-${index}`}
                 className={clsx(
                   "relative shrink-0",
                   isCurrentlyEditing ? "z-50" : "z-10"
@@ -426,7 +446,7 @@ export const FilterBar = ({
                       <Icon className="h-3.5 w-3.5 shrink-0 text-gray-600" />
                     ) : null}
                     <span className="max-w-48 truncate whitespace-nowrap sm:max-w-64">
-                      {isDefault ? "Opt-in (default)" : colDef?.label}
+                      {isDefault ? "Opt-in (default)" : formatFilterChipLabel(filter, colDef)}
                     </span>
                     <ChevronDown className="h-3.5 w-3.5 shrink-0 text-gray-500" />
                   </button>

--- a/src/components/volunteers/FilterBar.tsx
+++ b/src/components/volunteers/FilterBar.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { SortingState } from "@tanstack/react-table";
 import clsx from "clsx";
-import { FILTERABLE_COLUMNS } from "./volunteerColumns";
+import type { FilterableColumnDesc } from "./volunteerColumns";
 import { FilterModal, filterModalAlignRight } from "./FilterModal";
 import { DEFAULT_OPT_IN_FILTER } from "./useVolunteersData";
 import {
@@ -157,6 +157,7 @@ interface FilterBarProps {
   globalOp: "AND" | "OR";
   setGlobalOp: (op: "AND" | "OR") => void;
   optionsData: Record<string, string[]>;
+  filterableColumns: FilterableColumnDesc[];
   sorting: SortingState;
   setSorting: React.Dispatch<React.SetStateAction<SortingState>>;
 }
@@ -167,6 +168,7 @@ export const FilterBar = ({
   globalOp,
   setGlobalOp,
   optionsData,
+  filterableColumns,
   sorting,
   setSorting,
 }: FilterBarProps): React.JSX.Element | null => {
@@ -346,9 +348,7 @@ export const FilterBar = ({
           aria-label="Active filters and actions"
         >
           {filters.map((filter, index) => {
-            const colDef = FILTERABLE_COLUMNS.find(
-              (c) => c.id === filter.field
-            );
+            const colDef = filterableColumns.find((c) => c.id === filter.field);
             const isCurrentlyEditing = editingIndex === index;
             const Icon = colDef?.icon;
             const isDefault = isDefaultFilter(filter);
@@ -433,6 +433,7 @@ export const FilterBar = ({
                 )}
 
                 <FilterModal
+                  filterableColumns={filterableColumns}
                   isOpen={isCurrentlyEditing}
                   onClose={() => {
                     setEditingIndex(null);
@@ -484,6 +485,7 @@ export const FilterBar = ({
                 }}
                 onApply={handleApplyNew}
                 optionsData={optionsData}
+                filterableColumns={filterableColumns}
                 alignRight={newAlignRight}
                 anchorRect={isAddingNew ? newAnchorRect : null}
               />

--- a/src/components/volunteers/FilterModal.tsx
+++ b/src/components/volunteers/FilterModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { ColumnSelector } from "./ColumnSelector";
 import { FilterTuple } from "@/lib/api/getVolunteersByMultipleColumns";
 import { Trash2 } from "lucide-react";
+import toast from "react-hot-toast";
 import { VolunteerTag } from "./VolunteerTag";
 import clsx from "clsx";
 import {
@@ -61,6 +62,8 @@ export const FilterModal = ({
   const [selectedCol, setSelectedCol] = useState<string | null>(null);
   const [inputValue, setInputValue] = useState("");
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+  const [rangeMin, setRangeMin] = useState("");
+  const [rangeMax, setRangeMax] = useState("");
   const [miniOp, setMiniOp] = useState<"AND" | "OR">("OR");
 
   const colDef = filterableColumns.find((c) => c.id === selectedCol);
@@ -81,12 +84,31 @@ export const FilterModal = ({
         const initialColDef = filterableColumns.find(
           (c) => c.id === initialFilter.field
         );
-        if (initialColDef?.type === "text") {
+        if (initialColDef?.type === "number") {
+          const vals = initialFilter.values as string[];
+          if (
+            initialFilter.numberRange &&
+            Array.isArray(vals) &&
+            vals.length >= 2
+          ) {
+            setRangeMin(String(vals[0] ?? ""));
+            setRangeMax(String(vals[1] ?? ""));
+          } else {
+            setRangeMin("");
+            setRangeMax("");
+          }
+          setInputValue("");
+          setSelectedOptions([]);
+        } else if (initialColDef?.type === "text") {
           setInputValue(initialFilter.values[0] as string);
           setSelectedOptions([]);
+          setRangeMin("");
+          setRangeMax("");
         } else {
           setSelectedOptions(initialFilter.values as string[]);
           setInputValue("");
+          setRangeMin("");
+          setRangeMax("");
         }
         setActiveStep("SELECT_VALUES");
       } else {
@@ -94,6 +116,8 @@ export const FilterModal = ({
         setSelectedCol(null);
         setInputValue("");
         setSelectedOptions([]);
+        setRangeMin("");
+        setRangeMax("");
         setMiniOp("OR");
       }
     }
@@ -118,6 +142,49 @@ export const FilterModal = ({
   const handleApplyFilter = (): void => {
     if (!selectedCol) {
       onClose();
+      return;
+    }
+
+    if (colDef?.type === "number") {
+      const min = rangeMin.trim();
+      const max = rangeMax.trim();
+      if (min === "" && max === "") {
+        onApply(null);
+        return;
+      }
+      if (min !== "" && !Number.isFinite(Number(min))) {
+        toast.error("Enter a valid minimum number");
+        return;
+      }
+      if (max !== "" && !Number.isFinite(Number(max))) {
+        toast.error("Enter a valid maximum number");
+        return;
+      }
+      if (min !== "" && max !== "" && Number(min) > Number(max)) {
+        toast.error("Minimum must be less than or equal to maximum");
+        return;
+      }
+      const newFilter: FilterTuple = {
+        field: selectedCol,
+        miniOp: "AND",
+        values: [min, max],
+        numberRange: true,
+      };
+      if (initialFilter) {
+        if (
+          initialFilter.field === newFilter.field &&
+          initialFilter.miniOp === newFilter.miniOp &&
+          initialFilter.numberRange === true &&
+          compareArrays(
+            initialFilter.values as string[],
+            newFilter.values as string[]
+          )
+        ) {
+          onClose();
+          return;
+        }
+      }
+      onApply(newFilter);
       return;
     }
 
@@ -196,6 +263,8 @@ export const FilterModal = ({
               setSelectedCol(colId);
               setActiveStep("SELECT_VALUES");
               setInputValue("");
+              setRangeMin("");
+              setRangeMax("");
               setMiniOp("OR");
             }}
           />
@@ -244,6 +313,54 @@ export const FilterModal = ({
                 }}
                 className="w-full border border-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-300"
               />
+            ) : colDef?.type === "number" ? (
+              <div className="space-y-2">
+                <p className="text-xs text-gray-600">
+                  Include values from <span className="font-medium">min</span>{" "}
+                  to <span className="font-medium">max</span> (inclusive). Leave
+                  one side empty for no lower or upper bound.
+                </p>
+                <div className="flex gap-2 items-center">
+                  <label className="flex-1 min-w-0">
+                    <span className="sr-only">Minimum</span>
+                    <input
+                      ref={valueInputRef}
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="Min"
+                      value={rangeMin}
+                      onChange={(e) => setRangeMin(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          handleApplyFilter();
+                        }
+                      }}
+                      className="w-full border border-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-300"
+                    />
+                  </label>
+                  <span className="text-gray-400 shrink-0 text-sm" aria-hidden>
+                    –
+                  </span>
+                  <label className="flex-1 min-w-0">
+                    <span className="sr-only">Maximum</span>
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="Max"
+                      value={rangeMax}
+                      onChange={(e) => setRangeMax(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          handleApplyFilter();
+                        }
+                      }}
+                      className="w-full border border-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-300"
+                    />
+                  </label>
+                </div>
+              </div>
             ) : (
               <>
                 <input

--- a/src/components/volunteers/FilterModal.tsx
+++ b/src/components/volunteers/FilterModal.tsx
@@ -4,7 +4,10 @@ import { FilterTuple } from "@/lib/api/getVolunteersByMultipleColumns";
 import { Trash2 } from "lucide-react";
 import { VolunteerTag } from "./VolunteerTag";
 import clsx from "clsx";
-import { FILTERABLE_COLUMNS } from "./volunteerColumns";
+import {
+  FILTERABLE_COLUMNS,
+  type FilterableColumnDesc,
+} from "./volunteerColumns";
 
 const MODAL_WIDTH_PX = 288;
 const SCREEN_BUFFER_PX = 24;
@@ -33,6 +36,8 @@ interface FilterModalProps {
   onClose: () => void;
   onApply: (filter: FilterTuple | null) => void;
   optionsData: Record<string, string[]>;
+  /** When omitted, built-in filterable columns are used. */
+  filterableColumns?: FilterableColumnDesc[];
   initialFilter?: FilterTuple;
   alignRight?: boolean;
   /** When set, the panel is `position:fixed` so it is not clipped by horizontal scroll parents. */
@@ -44,10 +49,12 @@ export const FilterModal = ({
   onClose,
   onApply,
   optionsData,
+  filterableColumns: filterableColumnsProp,
   initialFilter,
   alignRight = false,
   anchorRect = null,
 }: FilterModalProps): React.JSX.Element | null => {
+  const filterableColumns = filterableColumnsProp ?? FILTERABLE_COLUMNS;
   const [activeStep, setActiveStep] = useState<
     "SELECT_COLUMN" | "SELECT_VALUES"
   >("SELECT_COLUMN");
@@ -56,9 +63,9 @@ export const FilterModal = ({
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [miniOp, setMiniOp] = useState<"AND" | "OR">("OR");
 
-  const colDef = FILTERABLE_COLUMNS.find((c) => c.id === selectedCol);
+  const colDef = filterableColumns.find((c) => c.id === selectedCol);
   const availableOptions = selectedCol ? optionsData[selectedCol] || [] : [];
-  const visibleColumns = FILTERABLE_COLUMNS.map((c) => ({
+  const visibleColumns = filterableColumns.map((c) => ({
     id: c.id,
     label: c.label,
     icon: c.icon,
@@ -71,7 +78,7 @@ export const FilterModal = ({
       if (initialFilter) {
         setSelectedCol(initialFilter.field);
         setMiniOp(initialFilter.miniOp || "OR");
-        const initialColDef = FILTERABLE_COLUMNS.find(
+        const initialColDef = filterableColumns.find(
           (c) => c.id === initialFilter.field
         );
         if (initialColDef?.type === "text") {
@@ -90,7 +97,7 @@ export const FilterModal = ({
         setMiniOp("OR");
       }
     }
-  }, [isOpen, initialFilter]);
+  }, [isOpen, initialFilter, filterableColumns]);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/volunteers/ManageColumnsModal.tsx
+++ b/src/components/volunteers/ManageColumnsModal.tsx
@@ -182,7 +182,11 @@ interface ManageColumnsModalProps {
   customColumns: CustomColumnRow[];
   columnOrder: string[];
   hiddenColumns: string[];
+  /** Last save time for column prefs; used when merging saved order with custom columns. */
+  prefsUpdatedAt?: string | null;
   onApplied: () => void | Promise<void>;
+  /** Called after column order/visibility is saved so the parent can reload prefs into React state. */
+  onPreferencesSaved?: () => void | Promise<void>;
 }
 
 export const ManageColumnsModal = ({
@@ -192,7 +196,9 @@ export const ManageColumnsModal = ({
   customColumns,
   columnOrder: initialOrder,
   hiddenColumns: initialHidden,
+  prefsUpdatedAt = null,
   onApplied,
+  onPreferencesSaved,
 }: ManageColumnsModalProps): React.JSX.Element | null => {
   const [order, setOrder] = useState<string[]>([]);
   const [hidden, setHidden] = useState<Set<string>>(new Set());
@@ -210,10 +216,21 @@ export const ManageColumnsModal = ({
   const [tagOptionsRaw, setTagOptionsRaw] = useState("");
   const [tagMulti, setTagMulti] = useState(false);
 
+  const customColumnIdsKey = useMemo(
+    () => customColumns.map((c) => c.id).join(","),
+    [customColumns]
+  );
+
+  /** Sync from parent only when the modal opens or the set of custom column ids changes — not when prefs refresh from our own persist (avoids clearing pending deletes). */
   useEffect(() => {
     if (!isOpen) return;
     const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
-    const base = orderedColumnIds(builtInIds, customColumns, initialOrder);
+    const base = orderedColumnIds(
+      builtInIds,
+      customColumns,
+      initialOrder,
+      prefsUpdatedAt
+    );
     setOrder(base);
     setHidden(new Set(initialHidden));
     setPendingAdds([]);
@@ -223,7 +240,9 @@ export const ManageColumnsModal = ({
     setTagOptionsRaw("");
     setTagMulti(false);
     setConfirmOpen(false);
-  }, [isOpen, customColumns, initialOrder, initialHidden]);
+    // initialOrder / initialHidden / prefsUpdatedAt intentionally omitted: read fresh when isOpen or customColumnIdsKey changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
+  }, [isOpen, customColumnIdsKey]);
 
   const persistPrefs = useCallback(
     async (nextOrder: string[], nextHidden: Set<string>): Promise<void> => {
@@ -234,12 +253,14 @@ export const ManageColumnsModal = ({
         ]);
         if (!res.success) {
           toast.error(res.error ?? "Could not save column preferences");
+        } else {
+          await onPreferencesSaved?.();
         }
       } finally {
         setSavingPrefs(false);
       }
     },
-    []
+    [onPreferencesSaved]
   );
 
   const handleToggleHidden = useCallback(
@@ -286,16 +307,12 @@ export const ManageColumnsModal = ({
     setPendingDeleteIds((prev) =>
       prev.includes(columnId) ? prev : [...prev, columnId]
     );
-    setOrder((prevOrder) => {
-      const nextOrder = prevOrder.filter((id) => id !== tid);
-      setHidden((prevHidden) => {
-        const nextHidden = new Set(prevHidden);
-        nextHidden.delete(tid);
-        void persistPrefs(nextOrder, nextHidden);
-        return nextHidden;
-      });
-      return nextOrder;
-    });
+    const nextOrder = order.filter((id) => id !== tid);
+    const nextHidden = new Set(hidden);
+    nextHidden.delete(tid);
+    setOrder(nextOrder);
+    setHidden(nextHidden);
+    void persistPrefs(nextOrder, nextHidden);
   };
 
   const handleAddPending = (): void => {
@@ -384,8 +401,14 @@ export const ManageColumnsModal = ({
         role="dialog"
         aria-modal="true"
         aria-labelledby="manage-columns-title"
+        onClick={() => {
+          if (!savingPrefs && !applying) onClose();
+        }}
       >
-        <div className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(90vh,640px)]">
+        <div
+          className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(90vh,640px)]"
+          onClick={(e) => e.stopPropagation()}
+        >
           <div className="px-4 py-3 border-b border-gray-100 shrink-0 flex items-start justify-between gap-2">
             <div>
               <h2
@@ -401,7 +424,8 @@ export const ManageColumnsModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="text-sm text-gray-600 hover:text-gray-900 px-2 py-1"
+              disabled={savingPrefs || applying}
+              className="text-sm text-gray-600 hover:text-gray-900 px-2 py-1 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Close
             </button>

--- a/src/components/volunteers/ManageColumnsModal.tsx
+++ b/src/components/volunteers/ManageColumnsModal.tsx
@@ -23,7 +23,15 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SortableContext = SortableContextBase as any;
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, Eye, EyeOff, Trash2, Plus, Loader2 } from "lucide-react";
+import {
+  GripVertical,
+  Eye,
+  EyeOff,
+  Trash2,
+  Plus,
+  Loader2,
+  ListOrdered,
+} from "lucide-react";
 import toast from "react-hot-toast";
 import {
   COLUMNS_CONFIG,
@@ -45,8 +53,15 @@ import {
   ColumnChangeLogModal,
   type ColumnChangeLogEntry,
 } from "./ColumnChangeLogModal";
+import { NON_HIDEABLE_COLUMN_IDS } from "@/lib/volunteerTable/columnVisibility";
 
 const ID_COL = "volunteer_id";
+
+const NON_HIDEABLE = new Set(NON_HIDEABLE_COLUMN_IDS);
+
+function isNonHideableColumn(id: string): boolean {
+  return NON_HIDEABLE.has(id);
+}
 
 function isFundamental(id: string): boolean {
   return (FUNDAMENTAL_COLUMN_IDS as readonly string[]).includes(id);
@@ -85,6 +100,7 @@ function buildRowMetas(customColumns: CustomColumnRow[]): RowMeta[] {
 function SortableRow({
   meta,
   hidden,
+  orgHidden,
   isAdmin,
   onToggleHidden,
   onDeleteCustom,
@@ -92,6 +108,7 @@ function SortableRow({
 }: {
   meta: RowMeta;
   hidden: boolean;
+  orgHidden: boolean;
   isAdmin: boolean;
   onToggleHidden: (id: string) => void;
   onDeleteCustom: (columnId: number) => void;
@@ -141,16 +158,31 @@ function SortableRow({
         </p>
         <p className="text-xs text-gray-500">
           {meta.kind === "custom" ? meta.dataType : "built-in"}
+          {orgHidden ? " · Hidden for all users" : ""}
         </p>
       </div>
-      {!locked && (
+      {!isNonHideableColumn(meta.id) && (!locked || orgHidden) && (
         <button
           type="button"
-          onClick={() => onToggleHidden(meta.id)}
-          disabled={disabled}
+          onClick={() => {
+            if (!orgHidden && !locked) onToggleHidden(meta.id);
+          }}
+          disabled={disabled || orgHidden || locked}
           className="p-2 rounded-lg text-gray-600 hover:bg-gray-100 disabled:opacity-40"
-          title={hidden ? "Show column" : "Hide column"}
-          aria-label={hidden ? `Show ${meta.label}` : `Hide ${meta.label}`}
+          title={
+            orgHidden
+              ? "Hidden for all users in Settings → Table Management"
+              : hidden
+                ? "Show column"
+                : "Hide column"
+          }
+          aria-label={
+            orgHidden
+              ? `${meta.label} hidden for all users`
+              : hidden
+                ? `Show ${meta.label}`
+                : `Hide ${meta.label}`
+          }
         >
           {hidden ? (
             <EyeOff className="h-4 w-4" />
@@ -184,6 +216,8 @@ interface ManageColumnsModalProps {
   hiddenColumns: string[];
   /** Last save time for column prefs; used when merging saved order with custom columns. */
   prefsUpdatedAt?: string | null;
+  /** Column ids hidden for everyone via Settings → Table Management. */
+  globalHiddenColumnIds?: string[];
   onApplied: () => void | Promise<void>;
   /** Called after column order/visibility is saved so the parent can reload prefs into React state. */
   onPreferencesSaved?: () => void | Promise<void>;
@@ -197,6 +231,7 @@ export const ManageColumnsModal = ({
   columnOrder: initialOrder,
   hiddenColumns: initialHidden,
   prefsUpdatedAt = null,
+  globalHiddenColumnIds = [],
   onApplied,
   onPreferencesSaved,
 }: ManageColumnsModalProps): React.JSX.Element | null => {
@@ -219,6 +254,11 @@ export const ManageColumnsModal = ({
   const customColumnIdsKey = useMemo(
     () => customColumns.map((c) => c.id).join(","),
     [customColumns]
+  );
+
+  const globalHiddenSet = useMemo(
+    () => new Set(globalHiddenColumnIds),
+    [globalHiddenColumnIds]
   );
 
   /** Sync from parent only when the modal opens or the set of custom column ids changes — not when prefs refresh from our own persist (avoids clearing pending deletes). */
@@ -265,6 +305,7 @@ export const ManageColumnsModal = ({
 
   const handleToggleHidden = useCallback(
     (id: string): void => {
+      if (isNonHideableColumn(id)) return;
       if (isFundamental(id)) return;
       const next = new Set(hidden);
       if (next.has(id)) next.delete(id);
@@ -406,7 +447,7 @@ export const ManageColumnsModal = ({
         }}
       >
         <div
-          className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(90vh,640px)]"
+          className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(92vh,720px)]"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="px-4 py-3 border-b border-gray-100 shrink-0 flex items-start justify-between gap-2">
@@ -418,7 +459,9 @@ export const ManageColumnsModal = ({
                 Manage columns
               </h2>
               <p className="text-sm text-gray-600 mt-0.5">
-                Reorder, show or hide columns. Visibility saves immediately.
+                {isAdmin
+                  ? "Reorder and show or hide columns, or add new custom fields."
+                  : "Drag to reorder columns and change which ones you see."}
               </p>
             </div>
             <button
@@ -431,103 +474,150 @@ export const ManageColumnsModal = ({
             </button>
           </div>
 
-          <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3 min-h-0">
+          <div className="flex-1 overflow-y-auto px-4 py-4 min-h-0 flex flex-col gap-6">
             {pendingSchemaCount > 0 && (
-              <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900">
+              <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900 shrink-0">
                 {pendingSchemaCount} pending schema change
-                {pendingSchemaCount === 1 ? "" : "s"} — use Apply changes to
-                confirm.
+                {pendingSchemaCount === 1 ? "" : "s"} — use{" "}
+                <span className="font-medium">Apply changes</span> in the footer
+                to confirm.
               </div>
             )}
 
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
+            <section
+              className="rounded-xl border border-gray-200 bg-slate-50/90 p-3 min-h-0"
+              aria-labelledby="manage-columns-order-heading"
             >
-              <SortableContext
-                items={sortableIds}
-                strategy={verticalListSortingStrategy}
-              >
-                <div className="space-y-2">
-                  {orderedMetas.map((meta) => (
-                    <SortableRow
-                      key={meta.id}
-                      meta={meta}
-                      hidden={hidden.has(meta.id)}
-                      isAdmin={isAdmin}
-                      onToggleHidden={handleToggleHidden}
-                      onDeleteCustom={handleQueueDelete}
-                      disabled={savingPrefs || applying}
-                    />
-                  ))}
+              <div className="flex items-start gap-2.5 mb-3">
+                <ListOrdered
+                  className="h-5 w-5 text-slate-500 shrink-0 mt-0.5"
+                  aria-hidden
+                />
+                <div className="min-w-0">
+                  <h3
+                    id="manage-columns-order-heading"
+                    className="text-sm font-semibold text-gray-900"
+                  >
+                    Column order & visibility
+                  </h3>
+                  <p className="text-xs text-gray-600 mt-1 leading-snug">
+                    Drag rows to reorder. Use the eye icon to show or hide
+                    columns for your account. Changes here save automatically.
+                  </p>
                 </div>
-              </SortableContext>
-            </DndContext>
+              </div>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={sortableIds}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-2">
+                    {orderedMetas.map((meta) => (
+                      <SortableRow
+                        key={meta.id}
+                        meta={meta}
+                        hidden={
+                          hidden.has(meta.id) || globalHiddenSet.has(meta.id)
+                        }
+                        orgHidden={globalHiddenSet.has(meta.id)}
+                        isAdmin={isAdmin}
+                        onToggleHidden={handleToggleHidden}
+                        onDeleteCustom={handleQueueDelete}
+                        disabled={savingPrefs || applying}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            </section>
 
             {isAdmin && (
-              <div className="rounded-lg border border-gray-200 p-3 space-y-2 mt-4">
-                <h3 className="text-sm font-semibold text-gray-800 flex items-center gap-2">
-                  <Plus className="h-4 w-4" />
-                  Add column
-                </h3>
-                <input
-                  type="text"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="Column name"
-                  className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
-                />
-                <select
-                  value={newType}
-                  onChange={(e) =>
-                    setNewType(
-                      e.target.value as NewCustomColumnInput["data_type"]
-                    )
-                  }
-                  className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
-                >
-                  <option value="text">Text</option>
-                  <option value="number">Number</option>
-                  <option value="boolean">Yes / No</option>
-                  <option value="tag">Tag</option>
-                </select>
-                {newType === "tag" && (
-                  <>
-                    <textarea
-                      value={tagOptionsRaw}
-                      onChange={(e) => setTagOptionsRaw(e.target.value)}
-                      placeholder="Options (comma or newline separated)"
-                      rows={2}
-                      className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
-                    />
-                    <label className="flex items-center gap-2 text-sm text-gray-700">
-                      <input
-                        type="checkbox"
-                        checked={tagMulti}
-                        onChange={(e) => setTagMulti(e.target.checked)}
+              <section
+                className="rounded-xl border border-dashed border-purple-200 bg-purple-50/50 p-3 space-y-3"
+                aria-labelledby="manage-columns-add-heading"
+              >
+                <div className="flex items-start gap-2.5">
+                  <Plus
+                    className="h-5 w-5 text-purple-600 shrink-0 mt-0.5"
+                    aria-hidden
+                  />
+                  <div className="min-w-0">
+                    <h3
+                      id="manage-columns-add-heading"
+                      className="text-sm font-semibold text-gray-900"
+                    >
+                      Add a custom column
+                    </h3>
+                    <p className="text-xs text-gray-600 mt-1 leading-snug">
+                      Create a new field below, then confirm with{" "}
+                      <span className="font-medium">Apply changes</span> — this
+                      updates the database schema, not just your view.
+                    </p>
+                  </div>
+                </div>
+                <div className="space-y-2 pt-1 border-t border-purple-100">
+                  <input
+                    type="text"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder="Column name"
+                    className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
+                  />
+                  <select
+                    value={newType}
+                    onChange={(e) =>
+                      setNewType(
+                        e.target.value as NewCustomColumnInput["data_type"]
+                      )
+                    }
+                    className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
+                  >
+                    <option value="text">Text</option>
+                    <option value="number">Number</option>
+                    <option value="boolean">Yes / No</option>
+                    <option value="tag">Tag</option>
+                  </select>
+                  {newType === "tag" && (
+                    <>
+                      <textarea
+                        value={tagOptionsRaw}
+                        onChange={(e) => setTagOptionsRaw(e.target.value)}
+                        placeholder="Options (comma or newline separated)"
+                        rows={2}
+                        className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
                       />
-                      Allow multiple tags
-                    </label>
-                  </>
-                )}
-                <button
-                  type="button"
-                  onClick={handleAddPending}
-                  className="w-full rounded-lg bg-purple-600 text-white text-sm font-medium py-2 hover:bg-purple-700"
-                >
-                  Add to pending
-                </button>
-                {pendingAdds.length > 0 && (
-                  <ul className="text-xs text-gray-600 space-y-1">
-                    {pendingAdds.map((p, i) => (
-                      <li key={i}>
-                        + {p.name} ({p.data_type})
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
+                      <label className="flex items-center gap-2 text-sm text-gray-700">
+                        <input
+                          type="checkbox"
+                          checked={tagMulti}
+                          onChange={(e) => setTagMulti(e.target.checked)}
+                        />
+                        Allow multiple tags
+                      </label>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleAddPending}
+                    className="w-full rounded-lg bg-purple-600 text-white text-sm font-medium py-2 hover:bg-purple-700"
+                  >
+                    Add to pending list
+                  </button>
+                  {pendingAdds.length > 0 && (
+                    <ul className="text-xs text-gray-600 space-y-1 border-t border-purple-100 pt-2">
+                      {pendingAdds.map((p, i) => (
+                        <li key={i}>
+                          + {p.name} ({p.data_type})
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </section>
             )}
           </div>
 

--- a/src/components/volunteers/ManageColumnsModal.tsx
+++ b/src/components/volunteers/ManageColumnsModal.tsx
@@ -27,18 +27,15 @@ import {
   GripVertical,
   Eye,
   EyeOff,
-  Trash2,
   Plus,
   Loader2,
   ListOrdered,
   ChevronDown,
-  X,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
   COLUMNS_CONFIG,
   FUNDAMENTAL_COLUMN_IDS,
-  tableIdForCustomColumn,
   parseCustomColumnTableId,
   orderedColumnIds,
 } from "./volunteerColumns";
@@ -48,7 +45,6 @@ import type {
 } from "@/lib/api/customColumns";
 import {
   createCustomColumnsAction,
-  deleteCustomColumnsAction,
   saveColumnPreferencesAction,
 } from "@/lib/api/actions";
 import {
@@ -66,7 +62,7 @@ function computeLayoutKey(order: string[], hidden: Set<string>): string {
   });
 }
 
-type BusyOp = "idle" | "savingLayout" | "applyingAdds" | "applyingDeletes";
+type BusyOp = "idle" | "savingLayout" | "applyingAdds";
 
 const NON_HIDEABLE = new Set(NON_HIDEABLE_COLUMN_IDS);
 
@@ -112,17 +108,13 @@ function SortableRow({
   meta,
   hidden,
   orgHidden,
-  isAdmin,
   onToggleHidden,
-  onDeleteCustom,
   disabled,
 }: {
   meta: RowMeta;
   hidden: boolean;
   orgHidden: boolean;
-  isAdmin: boolean;
   onToggleHidden: (id: string) => void;
-  onDeleteCustom: (columnId: number) => void;
   disabled: boolean;
 }): React.JSX.Element {
   const locked = meta.id === ID_COL || isFundamental(meta.id);
@@ -182,7 +174,7 @@ function SortableRow({
           className="p-2 rounded-lg text-gray-600 hover:bg-gray-100 disabled:opacity-40"
           title={
             orgHidden
-              ? "Hidden for all users in Settings → Table Management"
+              ? "Hidden for all users in Settings → Volunteers table"
               : hidden
                 ? "Show column"
                 : "Hide column"
@@ -200,18 +192,6 @@ function SortableRow({
           ) : (
             <Eye className="h-4 w-4" />
           )}
-        </button>
-      )}
-      {isAdmin && meta.kind === "custom" && meta.columnId >= 0 && (
-        <button
-          type="button"
-          onClick={() => onDeleteCustom(meta.columnId)}
-          disabled={disabled}
-          className="p-2 rounded-lg text-red-600 hover:bg-red-50 disabled:opacity-40"
-          title="Delete column"
-          aria-label={`Delete ${meta.label}`}
-        >
-          <Trash2 className="h-4 w-4" />
         </button>
       )}
     </div>
@@ -249,11 +229,9 @@ export const ManageColumnsModal = ({
   const [order, setOrder] = useState<string[]>([]);
   const [hidden, setHidden] = useState<Set<string>>(new Set());
   const [pendingAdds, setPendingAdds] = useState<NewCustomColumnInput[]>([]);
-  const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
   const [busyOp, setBusyOp] = useState<BusyOp>("idle");
   const [layoutSavedKey, setLayoutSavedKey] = useState("");
   const [confirmAddOpen, setConfirmAddOpen] = useState(false);
-  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [logOpen, setLogOpen] = useState(false);
   const [logEntries, setLogEntries] = useState<ColumnChangeLogEntry[]>([]);
 
@@ -275,33 +253,33 @@ export const ManageColumnsModal = ({
     [globalHiddenColumnIds]
   );
 
-  /** Sync from parent only when the modal opens or the set of custom column ids changes — not when prefs refresh from our own persist (avoids clearing pending deletes). */
+  /** Sync from parent only when the modal opens or the set of custom column ids changes — not when prefs refresh from our own persist. */
   useEffect(() => {
     if (!isOpen) return;
     const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
-    const base = orderedColumnIds(
-      builtInIds,
-      customColumns,
-      initialOrder,
-      prefsUpdatedAt
-    );
+    const base = isAdmin
+      ? orderedColumnIds(
+          builtInIds,
+          customColumns,
+          initialOrder,
+          prefsUpdatedAt
+        )
+      : initialOrder;
     setOrder(base);
     const h = new Set(initialHidden);
     setHidden(h);
     setLayoutSavedKey(computeLayoutKey(base, h));
     setPendingAdds([]);
-    setPendingDeleteIds([]);
     setNewName("");
     setNewType("text");
     setTagOptionsRaw("");
     setTagMulti(false);
     setConfirmAddOpen(false);
-    setConfirmDeleteOpen(false);
     setOrderSectionOpen(true);
     setAddSectionOpen(false);
     // initialOrder / initialHidden / prefsUpdatedAt intentionally omitted: read fresh when isOpen or customColumnIdsKey changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
-  }, [isOpen, customColumnIdsKey]);
+  }, [isOpen, customColumnIdsKey, isAdmin]);
 
   const handleSaveLayout = useCallback(async (): Promise<void> => {
     setBusyOp("savingLayout");
@@ -354,31 +332,6 @@ export const ManageColumnsModal = ({
     const merged = [ID_COL, ...withIdFirst.filter((id) => id !== ID_COL)];
     setOrder(merged);
   };
-
-  const handleQueueDelete = (columnId: number): void => {
-    const c = customColumns.find((x) => x.id === columnId);
-    if (!c) return;
-    const tid = tableIdForCustomColumn(c.column_key);
-    setPendingDeleteIds((prev) =>
-      prev.includes(columnId) ? prev : [...prev, columnId]
-    );
-    const nextOrder = order.filter((id) => id !== tid);
-    const nextHidden = new Set(hidden);
-    nextHidden.delete(tid);
-    setOrder(nextOrder);
-    setHidden(nextHidden);
-  };
-
-  const handleUnqueueDelete = useCallback(
-    (columnId: number): void => {
-      const c = customColumns.find((x) => x.id === columnId);
-      if (!c) return;
-      const tid = tableIdForCustomColumn(c.column_key);
-      setPendingDeleteIds((prev) => prev.filter((id) => id !== columnId));
-      setOrder((prev) => (prev.includes(tid) ? prev : [...prev, tid]));
-    },
-    [customColumns]
-  );
 
   const handleAddPending = (): void => {
     const name = newName.trim();
@@ -441,37 +394,9 @@ export const ManageColumnsModal = ({
     }
   };
 
-  const runApplyDeletes = async (): Promise<void> => {
-    if (pendingDeleteIds.length === 0) return;
-    setBusyOp("applyingDeletes");
-    setConfirmDeleteOpen(false);
-    const entries: ColumnChangeLogEntry[] = [];
-    try {
-      const delRes = await deleteCustomColumnsAction(pendingDeleteIds);
-      for (const r of delRes) {
-        const entry: ColumnChangeLogEntry = {
-          description: r.success ? r.label : `Delete failed: ${r.label}`,
-          success: r.success,
-        };
-        if (r.error) entry.error = r.error;
-        entries.push(entry);
-      }
-      setLogEntries(entries);
-      setLogOpen(true);
-      setPendingDeleteIds([]);
-      await onApplied();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Delete failed");
-    } finally {
-      setBusyOp("idle");
-    }
-  };
-
   if (!isOpen) return null;
 
-  const metas = buildRowMetas(
-    customColumns.filter((c) => !pendingDeleteIds.includes(c.id))
-  );
+  const metas = buildRowMetas(customColumns);
   const metaById = new Map(metas.map((m) => [m.id, m]));
   const orderedMetas = order
     .map((id) => metaById.get(id))
@@ -502,7 +427,7 @@ export const ManageColumnsModal = ({
               </h2>
               <p className="text-sm text-gray-600 mt-0.5">
                 {isAdmin
-                  ? "Reorder and show or hide columns, or add new custom fields."
+                  ? "Reorder and show or hide columns, or add new custom fields. To remove a custom column permanently, use Settings → Volunteers table."
                   : "Drag to reorder columns and change which ones you see."}
               </p>
             </div>
@@ -580,9 +505,7 @@ export const ManageColumnsModal = ({
                                 globalHiddenSet.has(meta.id)
                               }
                               orgHidden={globalHiddenSet.has(meta.id)}
-                              isAdmin={isAdmin}
                               onToggleHidden={handleToggleHidden}
-                              onDeleteCustom={handleQueueDelete}
                               disabled={busy}
                             />
                           ))}
@@ -590,39 +513,6 @@ export const ManageColumnsModal = ({
                       </SortableContext>
                     </DndContext>
                   </div>
-                  {isAdmin && pendingDeleteIds.length > 0 && (
-                    <div className="rounded-lg border border-red-200 bg-red-50/60 px-2.5 py-2 shrink-0">
-                      <p className="text-xs font-medium text-red-900 mb-1.5">
-                        Pending removal
-                      </p>
-                      <ul className="space-y-1">
-                        {pendingDeleteIds.map((colId) => {
-                          const c = customColumns.find((x) => x.id === colId);
-                          const label = c?.name ?? `Column ${colId}`;
-                          return (
-                            <li
-                              key={colId}
-                              className="flex items-center justify-between gap-2 min-w-0"
-                            >
-                              <span className="text-sm text-red-950 truncate">
-                                {label}
-                              </span>
-                              <button
-                                type="button"
-                                onClick={() => handleUnqueueDelete(colId)}
-                                disabled={busy}
-                                title="Undo removal"
-                                aria-label={`Keep column ${label}`}
-                                className="shrink-0 inline-flex items-center justify-center rounded-md p-1 text-red-700 hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed"
-                              >
-                                <X className="h-4 w-4" strokeWidth={2.25} />
-                              </button>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    </div>
-                  )}
                   <div className="flex flex-wrap gap-2 justify-end shrink-0 border-t border-gray-200/80 pt-3">
                     <button
                       type="button"
@@ -635,19 +525,6 @@ export const ManageColumnsModal = ({
                       )}
                       Save column layout
                     </button>
-                    {isAdmin && (
-                      <button
-                        type="button"
-                        onClick={() => setConfirmDeleteOpen(true)}
-                        disabled={pendingDeleteIds.length === 0 || busy}
-                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed"
-                      >
-                        {busyOp === "applyingDeletes" && (
-                          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
-                        )}
-                        Apply column removals
-                      </button>
-                    )}
                   </div>
                 </div>
               )}
@@ -838,49 +715,6 @@ export const ManageColumnsModal = ({
                   <Loader2 className="h-4 w-4 animate-spin" />
                 )}
                 Create columns
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {confirmDeleteOpen && (
-        <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black/50">
-          <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-4 space-y-3">
-            <h3 className="font-semibold text-gray-900">Remove columns</h3>
-            <p className="text-sm text-gray-600">
-              The following custom columns will be permanently removed from the
-              database.
-            </p>
-            <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1 max-h-48 overflow-y-auto">
-              {pendingDeleteIds.map((id) => {
-                const c = customColumns.find((x) => x.id === id);
-                return (
-                  <li key={`d-${id}`}>
-                    Delete column &quot;{c?.name ?? id}&quot;
-                  </li>
-                );
-              })}
-            </ul>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                type="button"
-                className="px-3 py-1.5 text-sm rounded-lg border border-gray-300"
-                onClick={() => setConfirmDeleteOpen(false)}
-                disabled={busyOp === "applyingDeletes"}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white disabled:opacity-50 inline-flex items-center gap-2 hover:bg-red-700"
-                onClick={() => void runApplyDeletes()}
-                disabled={busyOp === "applyingDeletes"}
-              >
-                {busyOp === "applyingDeletes" && (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                )}
-                Remove columns
               </button>
             </div>
           </div>

--- a/src/components/volunteers/ManageColumnsModal.tsx
+++ b/src/components/volunteers/ManageColumnsModal.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import clsx from "clsx";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext as SortableContextBase,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+
+/** Bridge until @dnd-kit types align with React 19 JSX return types. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SortableContext = SortableContextBase as any;
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Eye, EyeOff, Trash2, Plus, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+import {
+  COLUMNS_CONFIG,
+  FUNDAMENTAL_COLUMN_IDS,
+  tableIdForCustomColumn,
+  parseCustomColumnTableId,
+  orderedColumnIds,
+} from "./volunteerColumns";
+import type {
+  CustomColumnRow,
+  NewCustomColumnInput,
+} from "@/lib/api/customColumns";
+import {
+  createCustomColumnsAction,
+  deleteCustomColumnsAction,
+  saveColumnPreferencesAction,
+} from "@/lib/api/actions";
+import {
+  ColumnChangeLogModal,
+  type ColumnChangeLogEntry,
+} from "./ColumnChangeLogModal";
+
+const ID_COL = "volunteer_id";
+
+function isFundamental(id: string): boolean {
+  return (FUNDAMENTAL_COLUMN_IDS as readonly string[]).includes(id);
+}
+
+type RowMeta =
+  | { kind: "builtin"; id: string; label: string }
+  | {
+      kind: "custom";
+      id: string;
+      label: string;
+      columnId: number;
+      dataType: string;
+    };
+
+function buildRowMetas(customColumns: CustomColumnRow[]): RowMeta[] {
+  const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
+  const order = orderedColumnIds(builtInIds, customColumns, []);
+  return order.map((id) => {
+    const cfg = COLUMNS_CONFIG.find((c) => String(c.id) === id);
+    if (cfg) {
+      return { kind: "builtin" as const, id, label: cfg.label };
+    }
+    const key = parseCustomColumnTableId(id) ?? "";
+    const cc = customColumns.find((c) => c.column_key === key);
+    return {
+      kind: "custom" as const,
+      id,
+      label: cc?.name ?? id,
+      columnId: cc?.id ?? -1,
+      dataType: cc?.data_type ?? "",
+    };
+  });
+}
+
+function SortableRow({
+  meta,
+  hidden,
+  isAdmin,
+  onToggleHidden,
+  onDeleteCustom,
+  disabled,
+}: {
+  meta: RowMeta;
+  hidden: boolean;
+  isAdmin: boolean;
+  onToggleHidden: (id: string) => void;
+  onDeleteCustom: (columnId: number) => void;
+  disabled: boolean;
+}): React.JSX.Element {
+  const locked = meta.id === ID_COL || isFundamental(meta.id);
+  const sortable = !locked && meta.id !== ID_COL;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: meta.id, disabled: !sortable || disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={clsx(
+        "flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-2 py-2",
+        isDragging && "opacity-60 shadow-md z-10"
+      )}
+    >
+      {sortable ? (
+        <button
+          type="button"
+          className="p-1 text-gray-400 hover:text-gray-700 cursor-grab active:cursor-grabbing touch-none"
+          aria-label={`Drag to reorder ${meta.label}`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      ) : (
+        <span className="w-7 shrink-0" aria-hidden />
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">
+          {meta.label}
+        </p>
+        <p className="text-xs text-gray-500">
+          {meta.kind === "custom" ? meta.dataType : "built-in"}
+        </p>
+      </div>
+      {!locked && (
+        <button
+          type="button"
+          onClick={() => onToggleHidden(meta.id)}
+          disabled={disabled}
+          className="p-2 rounded-lg text-gray-600 hover:bg-gray-100 disabled:opacity-40"
+          title={hidden ? "Show column" : "Hide column"}
+          aria-label={hidden ? `Show ${meta.label}` : `Hide ${meta.label}`}
+        >
+          {hidden ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </button>
+      )}
+      {isAdmin && meta.kind === "custom" && meta.columnId >= 0 && (
+        <button
+          type="button"
+          onClick={() => onDeleteCustom(meta.columnId)}
+          disabled={disabled}
+          className="p-2 rounded-lg text-red-600 hover:bg-red-50 disabled:opacity-40"
+          title="Delete column"
+          aria-label={`Delete ${meta.label}`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface ManageColumnsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  isAdmin: boolean;
+  customColumns: CustomColumnRow[];
+  columnOrder: string[];
+  hiddenColumns: string[];
+  onApplied: () => void | Promise<void>;
+}
+
+export const ManageColumnsModal = ({
+  isOpen,
+  onClose,
+  isAdmin,
+  customColumns,
+  columnOrder: initialOrder,
+  hiddenColumns: initialHidden,
+  onApplied,
+}: ManageColumnsModalProps): React.JSX.Element | null => {
+  const [order, setOrder] = useState<string[]>([]);
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [pendingAdds, setPendingAdds] = useState<NewCustomColumnInput[]>([]);
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
+  const [savingPrefs, setSavingPrefs] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [logOpen, setLogOpen] = useState(false);
+  const [logEntries, setLogEntries] = useState<ColumnChangeLogEntry[]>([]);
+
+  const [newName, setNewName] = useState("");
+  const [newType, setNewType] =
+    useState<NewCustomColumnInput["data_type"]>("text");
+  const [tagOptionsRaw, setTagOptionsRaw] = useState("");
+  const [tagMulti, setTagMulti] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
+    const base = orderedColumnIds(builtInIds, customColumns, initialOrder);
+    setOrder(base);
+    setHidden(new Set(initialHidden));
+    setPendingAdds([]);
+    setPendingDeleteIds([]);
+    setNewName("");
+    setNewType("text");
+    setTagOptionsRaw("");
+    setTagMulti(false);
+    setConfirmOpen(false);
+  }, [isOpen, customColumns, initialOrder, initialHidden]);
+
+  const persistPrefs = useCallback(
+    async (nextOrder: string[], nextHidden: Set<string>): Promise<void> => {
+      setSavingPrefs(true);
+      try {
+        const res = await saveColumnPreferencesAction(nextOrder, [
+          ...nextHidden,
+        ]);
+        if (!res.success) {
+          toast.error(res.error ?? "Could not save column preferences");
+        }
+      } finally {
+        setSavingPrefs(false);
+      }
+    },
+    []
+  );
+
+  const handleToggleHidden = useCallback(
+    (id: string): void => {
+      if (isFundamental(id)) return;
+      const next = new Set(hidden);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      setHidden(next);
+      void persistPrefs(order, next);
+    },
+    [hidden, order, persistPrefs]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const sortableIds = useMemo(
+    () => order.filter((id) => id !== ID_COL),
+    [order]
+  );
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = order.indexOf(String(active.id));
+    const newIndex = order.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    const next = arrayMove(order, oldIndex, newIndex);
+    const withIdFirst = next.filter((id) => id !== ID_COL);
+    const merged = [ID_COL, ...withIdFirst.filter((id) => id !== ID_COL)];
+    setOrder(merged);
+    void persistPrefs(merged, hidden);
+  };
+
+  const handleQueueDelete = (columnId: number): void => {
+    const c = customColumns.find((x) => x.id === columnId);
+    if (!c) return;
+    const tid = tableIdForCustomColumn(c.column_key);
+    setPendingDeleteIds((prev) =>
+      prev.includes(columnId) ? prev : [...prev, columnId]
+    );
+    setOrder((prevOrder) => {
+      const nextOrder = prevOrder.filter((id) => id !== tid);
+      setHidden((prevHidden) => {
+        const nextHidden = new Set(prevHidden);
+        nextHidden.delete(tid);
+        void persistPrefs(nextOrder, nextHidden);
+        return nextHidden;
+      });
+      return nextOrder;
+    });
+  };
+
+  const handleAddPending = (): void => {
+    const name = newName.trim();
+    if (!name) {
+      toast.error("Enter a column name");
+      return;
+    }
+    if (newType === "tag") {
+      const tag_options = tagOptionsRaw
+        .split(/[,|\n]/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      setPendingAdds((prev) => [
+        ...prev,
+        { name, data_type: "tag", tag_options, is_multi: tagMulti },
+      ]);
+    } else {
+      setPendingAdds((prev) => [...prev, { name, data_type: newType }]);
+    }
+    setNewName("");
+    setTagOptionsRaw("");
+    setTagMulti(false);
+    setNewType("text");
+  };
+
+  const pendingSchemaCount = pendingAdds.length + pendingDeleteIds.length;
+
+  const runApply = async (): Promise<void> => {
+    setApplying(true);
+    const entries: ColumnChangeLogEntry[] = [];
+
+    try {
+      if (pendingAdds.length > 0) {
+        const createRes = await createCustomColumnsAction(pendingAdds);
+        for (const r of createRes) {
+          const entry: ColumnChangeLogEntry = {
+            description: r.success
+              ? `Add column: ${r.label}`
+              : `Add column failed: ${r.label}`,
+            success: r.success,
+          };
+          if (r.error) entry.error = r.error;
+          entries.push(entry);
+        }
+      }
+      if (pendingDeleteIds.length > 0) {
+        const delRes = await deleteCustomColumnsAction(pendingDeleteIds);
+        for (const r of delRes) {
+          const entry: ColumnChangeLogEntry = {
+            description: r.success ? r.label : `Delete failed: ${r.label}`,
+            success: r.success,
+          };
+          if (r.error) entry.error = r.error;
+          entries.push(entry);
+        }
+      }
+
+      setLogEntries(entries);
+      setLogOpen(true);
+      setPendingAdds([]);
+      setPendingDeleteIds([]);
+      setConfirmOpen(false);
+      await onApplied();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Apply failed");
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const metas = buildRowMetas(
+    customColumns.filter((c) => !pendingDeleteIds.includes(c.id))
+  );
+  const metaById = new Map(metas.map((m) => [m.id, m]));
+  const orderedMetas = order
+    .map((id) => metaById.get(id))
+    .filter((m): m is RowMeta => m !== undefined);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="manage-columns-title"
+      >
+        <div className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(90vh,640px)]">
+          <div className="px-4 py-3 border-b border-gray-100 shrink-0 flex items-start justify-between gap-2">
+            <div>
+              <h2
+                id="manage-columns-title"
+                className="text-lg font-semibold text-gray-900"
+              >
+                Manage columns
+              </h2>
+              <p className="text-sm text-gray-600 mt-0.5">
+                Reorder, show or hide columns. Visibility saves immediately.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-sm text-gray-600 hover:text-gray-900 px-2 py-1"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3 min-h-0">
+            {pendingSchemaCount > 0 && (
+              <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900">
+                {pendingSchemaCount} pending schema change
+                {pendingSchemaCount === 1 ? "" : "s"} — use Apply changes to
+                confirm.
+              </div>
+            )}
+
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortableIds}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-2">
+                  {orderedMetas.map((meta) => (
+                    <SortableRow
+                      key={meta.id}
+                      meta={meta}
+                      hidden={hidden.has(meta.id)}
+                      isAdmin={isAdmin}
+                      onToggleHidden={handleToggleHidden}
+                      onDeleteCustom={handleQueueDelete}
+                      disabled={savingPrefs || applying}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+
+            {isAdmin && (
+              <div className="rounded-lg border border-gray-200 p-3 space-y-2 mt-4">
+                <h3 className="text-sm font-semibold text-gray-800 flex items-center gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add column
+                </h3>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Column name"
+                  className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
+                />
+                <select
+                  value={newType}
+                  onChange={(e) =>
+                    setNewType(
+                      e.target.value as NewCustomColumnInput["data_type"]
+                    )
+                  }
+                  className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
+                >
+                  <option value="text">Text</option>
+                  <option value="number">Number</option>
+                  <option value="boolean">Yes / No</option>
+                  <option value="tag">Tag</option>
+                </select>
+                {newType === "tag" && (
+                  <>
+                    <textarea
+                      value={tagOptionsRaw}
+                      onChange={(e) => setTagOptionsRaw(e.target.value)}
+                      placeholder="Options (comma or newline separated)"
+                      rows={2}
+                      className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm"
+                    />
+                    <label className="flex items-center gap-2 text-sm text-gray-700">
+                      <input
+                        type="checkbox"
+                        checked={tagMulti}
+                        onChange={(e) => setTagMulti(e.target.checked)}
+                      />
+                      Allow multiple tags
+                    </label>
+                  </>
+                )}
+                <button
+                  type="button"
+                  onClick={handleAddPending}
+                  className="w-full rounded-lg bg-purple-600 text-white text-sm font-medium py-2 hover:bg-purple-700"
+                >
+                  Add to pending
+                </button>
+                {pendingAdds.length > 0 && (
+                  <ul className="text-xs text-gray-600 space-y-1">
+                    {pendingAdds.map((p, i) => (
+                      <li key={i}>
+                        + {p.name} ({p.data_type})
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="px-4 py-3 border-t border-gray-100 shrink-0 flex flex-wrap gap-2 justify-end">
+            {isAdmin && (
+              <button
+                type="button"
+                disabled={pendingSchemaCount === 0 || applying}
+                onClick={() => setConfirmOpen(true)}
+                className={clsx(
+                  "rounded-lg px-4 py-2 text-sm font-medium",
+                  "bg-gray-900 text-white hover:bg-gray-800",
+                  "disabled:opacity-40 disabled:cursor-not-allowed"
+                )}
+              >
+                Apply changes
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {confirmOpen && (
+        <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black/50">
+          <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-4 space-y-3">
+            <h3 className="font-semibold text-gray-900">
+              Confirm schema changes
+            </h3>
+            <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1 max-h-48 overflow-y-auto">
+              {pendingAdds.map((p, i) => (
+                <li key={`a-${i}`}>
+                  Add column &quot;{p.name}&quot; ({p.data_type})
+                </li>
+              ))}
+              {pendingDeleteIds.map((id) => {
+                const c = customColumns.find((x) => x.id === id);
+                return (
+                  <li key={`d-${id}`}>
+                    Delete column &quot;{c?.name ?? id}&quot;
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="px-3 py-1.5 text-sm rounded-lg border border-gray-300"
+                onClick={() => setConfirmOpen(false)}
+                disabled={applying}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white disabled:opacity-50 inline-flex items-center gap-2"
+                onClick={() => void runApply()}
+                disabled={applying}
+              >
+                {applying && <Loader2 className="h-4 w-4 animate-spin" />}
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ColumnChangeLogModal
+        isOpen={logOpen}
+        onClose={() => setLogOpen(false)}
+        entries={logEntries}
+      />
+    </>
+  );
+};

--- a/src/components/volunteers/ManageColumnsModal.tsx
+++ b/src/components/volunteers/ManageColumnsModal.tsx
@@ -31,6 +31,8 @@ import {
   Plus,
   Loader2,
   ListOrdered,
+  ChevronDown,
+  X,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
@@ -56,6 +58,15 @@ import {
 import { NON_HIDEABLE_COLUMN_IDS } from "@/lib/volunteerTable/columnVisibility";
 
 const ID_COL = "volunteer_id";
+
+function computeLayoutKey(order: string[], hidden: Set<string>): string {
+  return JSON.stringify({
+    order,
+    hidden: [...hidden].sort(),
+  });
+}
+
+type BusyOp = "idle" | "savingLayout" | "applyingAdds" | "applyingDeletes";
 
 const NON_HIDEABLE = new Set(NON_HIDEABLE_COLUMN_IDS);
 
@@ -135,7 +146,7 @@ function SortableRow({
       ref={setNodeRef}
       style={style}
       className={clsx(
-        "flex items-center gap-2 rounded-lg border border-gray-100 bg-white px-2 py-2",
+        "flex min-w-0 items-center gap-2 rounded-lg border border-gray-100 bg-white px-2 py-2",
         isDragging && "opacity-60 shadow-md z-10"
       )}
     >
@@ -156,7 +167,7 @@ function SortableRow({
         <p className="text-sm font-medium text-gray-900 truncate">
           {meta.label}
         </p>
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-gray-500 line-clamp-2 wrap-break-word">
           {meta.kind === "custom" ? meta.dataType : "built-in"}
           {orgHidden ? " · Hidden for all users" : ""}
         </p>
@@ -239,9 +250,10 @@ export const ManageColumnsModal = ({
   const [hidden, setHidden] = useState<Set<string>>(new Set());
   const [pendingAdds, setPendingAdds] = useState<NewCustomColumnInput[]>([]);
   const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
-  const [savingPrefs, setSavingPrefs] = useState(false);
-  const [applying, setApplying] = useState(false);
-  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busyOp, setBusyOp] = useState<BusyOp>("idle");
+  const [layoutSavedKey, setLayoutSavedKey] = useState("");
+  const [confirmAddOpen, setConfirmAddOpen] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [logOpen, setLogOpen] = useState(false);
   const [logEntries, setLogEntries] = useState<ColumnChangeLogEntry[]>([]);
 
@@ -250,6 +262,8 @@ export const ManageColumnsModal = ({
     useState<NewCustomColumnInput["data_type"]>("text");
   const [tagOptionsRaw, setTagOptionsRaw] = useState("");
   const [tagMulti, setTagMulti] = useState(false);
+  const [orderSectionOpen, setOrderSectionOpen] = useState(true);
+  const [addSectionOpen, setAddSectionOpen] = useState(false);
 
   const customColumnIdsKey = useMemo(
     () => customColumns.map((c) => c.id).join(","),
@@ -272,36 +286,38 @@ export const ManageColumnsModal = ({
       prefsUpdatedAt
     );
     setOrder(base);
-    setHidden(new Set(initialHidden));
+    const h = new Set(initialHidden);
+    setHidden(h);
+    setLayoutSavedKey(computeLayoutKey(base, h));
     setPendingAdds([]);
     setPendingDeleteIds([]);
     setNewName("");
     setNewType("text");
     setTagOptionsRaw("");
     setTagMulti(false);
-    setConfirmOpen(false);
+    setConfirmAddOpen(false);
+    setConfirmDeleteOpen(false);
+    setOrderSectionOpen(true);
+    setAddSectionOpen(false);
     // initialOrder / initialHidden / prefsUpdatedAt intentionally omitted: read fresh when isOpen or customColumnIdsKey changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
   }, [isOpen, customColumnIdsKey]);
 
-  const persistPrefs = useCallback(
-    async (nextOrder: string[], nextHidden: Set<string>): Promise<void> => {
-      setSavingPrefs(true);
-      try {
-        const res = await saveColumnPreferencesAction(nextOrder, [
-          ...nextHidden,
-        ]);
-        if (!res.success) {
-          toast.error(res.error ?? "Could not save column preferences");
-        } else {
-          await onPreferencesSaved?.();
-        }
-      } finally {
-        setSavingPrefs(false);
+  const handleSaveLayout = useCallback(async (): Promise<void> => {
+    setBusyOp("savingLayout");
+    try {
+      const res = await saveColumnPreferencesAction(order, [...hidden]);
+      if (!res.success) {
+        toast.error(res.error ?? "Could not save column preferences");
+        return;
       }
-    },
-    [onPreferencesSaved]
-  );
+      setLayoutSavedKey(computeLayoutKey(order, hidden));
+      await onPreferencesSaved?.();
+      toast.success("Column layout saved");
+    } finally {
+      setBusyOp("idle");
+    }
+  }, [order, hidden, onPreferencesSaved]);
 
   const handleToggleHidden = useCallback(
     (id: string): void => {
@@ -311,9 +327,8 @@ export const ManageColumnsModal = ({
       if (next.has(id)) next.delete(id);
       else next.add(id);
       setHidden(next);
-      void persistPrefs(order, next);
     },
-    [hidden, order, persistPrefs]
+    [hidden]
   );
 
   const sensors = useSensors(
@@ -338,7 +353,6 @@ export const ManageColumnsModal = ({
     const withIdFirst = next.filter((id) => id !== ID_COL);
     const merged = [ID_COL, ...withIdFirst.filter((id) => id !== ID_COL)];
     setOrder(merged);
-    void persistPrefs(merged, hidden);
   };
 
   const handleQueueDelete = (columnId: number): void => {
@@ -353,8 +367,18 @@ export const ManageColumnsModal = ({
     nextHidden.delete(tid);
     setOrder(nextOrder);
     setHidden(nextHidden);
-    void persistPrefs(nextOrder, nextHidden);
   };
+
+  const handleUnqueueDelete = useCallback(
+    (columnId: number): void => {
+      const c = customColumns.find((x) => x.id === columnId);
+      if (!c) return;
+      const tid = tableIdForCustomColumn(c.column_key);
+      setPendingDeleteIds((prev) => prev.filter((id) => id !== columnId));
+      setOrder((prev) => (prev.includes(tid) ? prev : [...prev, tid]));
+    },
+    [customColumns]
+  );
 
   const handleAddPending = (): void => {
     const name = newName.trim();
@@ -380,48 +404,66 @@ export const ManageColumnsModal = ({
     setNewType("text");
   };
 
-  const pendingSchemaCount = pendingAdds.length + pendingDeleteIds.length;
+  const layoutDirty = useMemo(
+    () =>
+      layoutSavedKey !== "" &&
+      computeLayoutKey(order, hidden) !== layoutSavedKey,
+    [order, hidden, layoutSavedKey]
+  );
 
-  const runApply = async (): Promise<void> => {
-    setApplying(true);
+  const busy = busyOp !== "idle";
+
+  const runApplyAdds = async (): Promise<void> => {
+    if (pendingAdds.length === 0) return;
+    setBusyOp("applyingAdds");
+    setConfirmAddOpen(false);
     const entries: ColumnChangeLogEntry[] = [];
-
     try {
-      if (pendingAdds.length > 0) {
-        const createRes = await createCustomColumnsAction(pendingAdds);
-        for (const r of createRes) {
-          const entry: ColumnChangeLogEntry = {
-            description: r.success
-              ? `Add column: ${r.label}`
-              : `Add column failed: ${r.label}`,
-            success: r.success,
-          };
-          if (r.error) entry.error = r.error;
-          entries.push(entry);
-        }
+      const createRes = await createCustomColumnsAction(pendingAdds);
+      for (const r of createRes) {
+        const entry: ColumnChangeLogEntry = {
+          description: r.success
+            ? `Add column: ${r.label}`
+            : `Add column failed: ${r.label}`,
+          success: r.success,
+        };
+        if (r.error) entry.error = r.error;
+        entries.push(entry);
       }
-      if (pendingDeleteIds.length > 0) {
-        const delRes = await deleteCustomColumnsAction(pendingDeleteIds);
-        for (const r of delRes) {
-          const entry: ColumnChangeLogEntry = {
-            description: r.success ? r.label : `Delete failed: ${r.label}`,
-            success: r.success,
-          };
-          if (r.error) entry.error = r.error;
-          entries.push(entry);
-        }
-      }
-
       setLogEntries(entries);
       setLogOpen(true);
       setPendingAdds([]);
-      setPendingDeleteIds([]);
-      setConfirmOpen(false);
       await onApplied();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Apply failed");
+      toast.error(e instanceof Error ? e.message : "Create failed");
     } finally {
-      setApplying(false);
+      setBusyOp("idle");
+    }
+  };
+
+  const runApplyDeletes = async (): Promise<void> => {
+    if (pendingDeleteIds.length === 0) return;
+    setBusyOp("applyingDeletes");
+    setConfirmDeleteOpen(false);
+    const entries: ColumnChangeLogEntry[] = [];
+    try {
+      const delRes = await deleteCustomColumnsAction(pendingDeleteIds);
+      for (const r of delRes) {
+        const entry: ColumnChangeLogEntry = {
+          description: r.success ? r.label : `Delete failed: ${r.label}`,
+          success: r.success,
+        };
+        if (r.error) entry.error = r.error;
+        entries.push(entry);
+      }
+      setLogEntries(entries);
+      setLogOpen(true);
+      setPendingDeleteIds([]);
+      await onApplied();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setBusyOp("idle");
     }
   };
 
@@ -443,11 +485,11 @@ export const ManageColumnsModal = ({
         aria-modal="true"
         aria-labelledby="manage-columns-title"
         onClick={() => {
-          if (!savingPrefs && !applying) onClose();
+          if (!busy) onClose();
         }}
       >
         <div
-          className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-xl flex flex-col max-h-[min(92vh,720px)]"
+          className="flex w-full max-w-xl min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl max-h-[min(92vh,820px)]"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="px-4 py-3 border-b border-gray-100 shrink-0 flex items-start justify-between gap-2">
@@ -467,191 +509,350 @@ export const ManageColumnsModal = ({
             <button
               type="button"
               onClick={onClose}
-              disabled={savingPrefs || applying}
+              disabled={busy}
               className="text-sm text-gray-600 hover:text-gray-900 px-2 py-1 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Close
             </button>
           </div>
 
-          <div className="flex-1 overflow-y-auto px-4 py-4 min-h-0 flex flex-col gap-6">
-            {pendingSchemaCount > 0 && (
-              <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900 shrink-0">
-                {pendingSchemaCount} pending schema change
-                {pendingSchemaCount === 1 ? "" : "s"} — use{" "}
-                <span className="font-medium">Apply changes</span> in the footer
-                to confirm.
-              </div>
-            )}
-
+          <div className="flex min-h-0 min-w-0 w-full flex-1 flex-col gap-3 overflow-hidden px-4 py-4">
             <section
-              className="rounded-xl border border-gray-200 bg-slate-50/90 p-3 min-h-0"
+              className={clsx(
+                "rounded-xl border border-gray-200 bg-slate-50/90 min-w-0 flex flex-col min-h-0 overflow-hidden p-3",
+                orderSectionOpen && "flex-1"
+              )}
               aria-labelledby="manage-columns-order-heading"
             >
-              <div className="flex items-start gap-2.5 mb-3">
+              <button
+                type="button"
+                className="flex w-full items-start gap-2 rounded-lg -m-0.5 p-1.5 text-left hover:bg-slate-100/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1"
+                onClick={() => setOrderSectionOpen((o) => !o)}
+                aria-expanded={orderSectionOpen}
+                aria-controls="manage-columns-order-panel"
+                id="manage-columns-order-heading"
+              >
+                <ChevronDown
+                  className={clsx(
+                    "h-5 w-5 shrink-0 text-slate-500 transition-transform mt-0.5",
+                    !orderSectionOpen && "-rotate-90"
+                  )}
+                  aria-hidden
+                />
                 <ListOrdered
                   className="h-5 w-5 text-slate-500 shrink-0 mt-0.5"
                   aria-hidden
                 />
-                <div className="min-w-0">
-                  <h3
-                    id="manage-columns-order-heading"
-                    className="text-sm font-semibold text-gray-900"
-                  >
+                <div className="min-w-0 flex-1">
+                  <h3 className="text-sm font-semibold text-gray-900">
                     Column order & visibility
                   </h3>
                   <p className="text-xs text-gray-600 mt-1 leading-snug">
                     Drag rows to reorder. Use the eye icon to show or hide
-                    columns for your account. Changes here save automatically.
+                    columns for your account. Click{" "}
+                    <span className="font-medium">Save column layout</span> when
+                    you are ready to persist order and visibility.
                   </p>
                 </div>
-              </div>
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={sortableIds}
-                  strategy={verticalListSortingStrategy}
+              </button>
+              {orderSectionOpen && (
+                <div
+                  id="manage-columns-order-panel"
+                  className="mt-2 flex min-h-0 min-w-0 flex-1 flex-col gap-3"
                 >
-                  <div className="space-y-2">
-                    {orderedMetas.map((meta) => (
-                      <SortableRow
-                        key={meta.id}
-                        meta={meta}
-                        hidden={
-                          hidden.has(meta.id) || globalHiddenSet.has(meta.id)
-                        }
-                        orgHidden={globalHiddenSet.has(meta.id)}
-                        isAdmin={isAdmin}
-                        onToggleHidden={handleToggleHidden}
-                        onDeleteCustom={handleQueueDelete}
-                        disabled={savingPrefs || applying}
-                      />
-                    ))}
+                  <div className="min-h-48 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain pr-0.5">
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={handleDragEnd}
+                    >
+                      <SortableContext
+                        items={sortableIds}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        <div className="space-y-2">
+                          {orderedMetas.map((meta) => (
+                            <SortableRow
+                              key={meta.id}
+                              meta={meta}
+                              hidden={
+                                hidden.has(meta.id) ||
+                                globalHiddenSet.has(meta.id)
+                              }
+                              orgHidden={globalHiddenSet.has(meta.id)}
+                              isAdmin={isAdmin}
+                              onToggleHidden={handleToggleHidden}
+                              onDeleteCustom={handleQueueDelete}
+                              disabled={busy}
+                            />
+                          ))}
+                        </div>
+                      </SortableContext>
+                    </DndContext>
                   </div>
-                </SortableContext>
-              </DndContext>
+                  {isAdmin && pendingDeleteIds.length > 0 && (
+                    <div className="rounded-lg border border-red-200 bg-red-50/60 px-2.5 py-2 shrink-0">
+                      <p className="text-xs font-medium text-red-900 mb-1.5">
+                        Pending removal
+                      </p>
+                      <ul className="space-y-1">
+                        {pendingDeleteIds.map((colId) => {
+                          const c = customColumns.find((x) => x.id === colId);
+                          const label = c?.name ?? `Column ${colId}`;
+                          return (
+                            <li
+                              key={colId}
+                              className="flex items-center justify-between gap-2 min-w-0"
+                            >
+                              <span className="text-sm text-red-950 truncate">
+                                {label}
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => handleUnqueueDelete(colId)}
+                                disabled={busy}
+                                title="Undo removal"
+                                aria-label={`Keep column ${label}`}
+                                className="shrink-0 inline-flex items-center justify-center rounded-md p-1 text-red-700 hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed"
+                              >
+                                <X className="h-4 w-4" strokeWidth={2.25} />
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  )}
+                  <div className="flex flex-wrap gap-2 justify-end shrink-0 border-t border-gray-200/80 pt-3">
+                    <button
+                      type="button"
+                      onClick={() => void handleSaveLayout()}
+                      disabled={!layoutDirty || busy}
+                      className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      {busyOp === "savingLayout" && (
+                        <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                      )}
+                      Save column layout
+                    </button>
+                    {isAdmin && (
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDeleteOpen(true)}
+                        disabled={pendingDeleteIds.length === 0 || busy}
+                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        {busyOp === "applyingDeletes" && (
+                          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                        )}
+                        Apply column removals
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
             </section>
 
             {isAdmin && (
               <section
-                className="rounded-xl border border-dashed border-purple-200 bg-purple-50/50 p-3 space-y-3"
+                className="shrink-0 rounded-xl border border-dashed border-purple-200 bg-purple-50/50 p-3 min-w-0 flex flex-col overflow-hidden max-h-[min(48vh,26rem)]"
                 aria-labelledby="manage-columns-add-heading"
               >
-                <div className="flex items-start gap-2.5">
+                <button
+                  type="button"
+                  className="flex w-full items-start gap-2 rounded-lg -m-0.5 p-1.5 text-left hover:bg-purple-100/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-1"
+                  onClick={() => setAddSectionOpen((o) => !o)}
+                  aria-expanded={addSectionOpen}
+                  aria-controls="manage-columns-add-panel"
+                  id="manage-columns-add-heading"
+                >
+                  <ChevronDown
+                    className={clsx(
+                      "h-5 w-5 shrink-0 text-purple-600 transition-transform mt-0.5",
+                      !addSectionOpen && "-rotate-90"
+                    )}
+                    aria-hidden
+                  />
                   <Plus
                     className="h-5 w-5 text-purple-600 shrink-0 mt-0.5"
                     aria-hidden
                   />
-                  <div className="min-w-0">
-                    <h3
-                      id="manage-columns-add-heading"
-                      className="text-sm font-semibold text-gray-900"
-                    >
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-sm font-semibold text-gray-900">
                       Add a custom column
                     </h3>
                     <p className="text-xs text-gray-600 mt-1 leading-snug">
-                      Create a new field below, then confirm with{" "}
-                      <span className="font-medium">Apply changes</span> — this
-                      updates the database schema, not just your view.
+                      Add fields to the pending list, then use{" "}
+                      <span className="font-medium">Create columns</span> to add
+                      them to the database (not just your view).
                     </p>
                   </div>
-                </div>
-                <div className="space-y-2 pt-1 border-t border-purple-100">
-                  <input
-                    type="text"
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    placeholder="Column name"
-                    className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
-                  />
-                  <select
-                    value={newType}
-                    onChange={(e) =>
-                      setNewType(
-                        e.target.value as NewCustomColumnInput["data_type"]
-                      )
-                    }
-                    className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
+                </button>
+                {addSectionOpen && (
+                  <div
+                    id="manage-columns-add-panel"
+                    className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden border-t border-purple-100 pt-3"
                   >
-                    <option value="text">Text</option>
-                    <option value="number">Number</option>
-                    <option value="boolean">Yes / No</option>
-                    <option value="tag">Tag</option>
-                  </select>
-                  {newType === "tag" && (
-                    <>
-                      <textarea
-                        value={tagOptionsRaw}
-                        onChange={(e) => setTagOptionsRaw(e.target.value)}
-                        placeholder="Options (comma or newline separated)"
-                        rows={2}
-                        className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm"
-                      />
-                      <label className="flex items-center gap-2 text-sm text-gray-700">
+                    <div className="space-y-3">
+                      <div>
+                        <label
+                          htmlFor="manage-columns-new-name"
+                          className="mb-1 block text-xs font-medium text-gray-700"
+                        >
+                          Column name
+                        </label>
                         <input
-                          type="checkbox"
-                          checked={tagMulti}
-                          onChange={(e) => setTagMulti(e.target.checked)}
+                          id="manage-columns-new-name"
+                          type="text"
+                          value={newName}
+                          onChange={(e) => setNewName(e.target.value)}
+                          disabled={busy}
+                          placeholder="e.g. T-shirt size"
+                          className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm disabled:opacity-50"
                         />
-                        Allow multiple tags
-                      </label>
-                    </>
-                  )}
-                  <button
-                    type="button"
-                    onClick={handleAddPending}
-                    className="w-full rounded-lg bg-purple-600 text-white text-sm font-medium py-2 hover:bg-purple-700"
-                  >
-                    Add to pending list
-                  </button>
-                  {pendingAdds.length > 0 && (
-                    <ul className="text-xs text-gray-600 space-y-1 border-t border-purple-100 pt-2">
-                      {pendingAdds.map((p, i) => (
-                        <li key={i}>
-                          + {p.name} ({p.data_type})
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              </section>
-            )}
-          </div>
-
-          <div className="px-4 py-3 border-t border-gray-100 shrink-0 flex flex-wrap gap-2 justify-end">
-            {isAdmin && (
-              <button
-                type="button"
-                disabled={pendingSchemaCount === 0 || applying}
-                onClick={() => setConfirmOpen(true)}
-                className={clsx(
-                  "rounded-lg px-4 py-2 text-sm font-medium",
-                  "bg-gray-900 text-white hover:bg-gray-800",
-                  "disabled:opacity-40 disabled:cursor-not-allowed"
+                      </div>
+                      <div>
+                        <label
+                          htmlFor="manage-columns-new-type"
+                          className="mb-1 block text-xs font-medium text-gray-700"
+                        >
+                          Data type
+                        </label>
+                        <select
+                          id="manage-columns-new-type"
+                          value={newType}
+                          onChange={(e) =>
+                            setNewType(
+                              e.target
+                                .value as NewCustomColumnInput["data_type"]
+                            )
+                          }
+                          disabled={busy}
+                          className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm disabled:opacity-50"
+                        >
+                          <option value="text">Text</option>
+                          <option value="number">Number</option>
+                          <option value="boolean">Yes / No</option>
+                          <option value="tag">Tag</option>
+                        </select>
+                      </div>
+                      {newType === "tag" && (
+                        <>
+                          <div>
+                            <label
+                              htmlFor="manage-columns-tag-options"
+                              className="mb-1 block text-xs font-medium text-gray-700"
+                            >
+                              Tag options (optional)
+                            </label>
+                            <textarea
+                              id="manage-columns-tag-options"
+                              value={tagOptionsRaw}
+                              onChange={(e) => setTagOptionsRaw(e.target.value)}
+                              disabled={busy}
+                              placeholder="Comma or newline separated"
+                              rows={2}
+                              className="w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm disabled:opacity-50"
+                            />
+                          </div>
+                          <label className="flex items-center gap-2 text-sm text-gray-700">
+                            <input
+                              type="checkbox"
+                              checked={tagMulti}
+                              disabled={busy}
+                              onChange={(e) => setTagMulti(e.target.checked)}
+                            />
+                            Allow multiple tags
+                          </label>
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={handleAddPending}
+                        disabled={busy}
+                        className="w-full rounded-lg bg-purple-600 text-white text-sm font-medium py-2 hover:bg-purple-700 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        Add to pending list
+                      </button>
+                      {pendingAdds.length > 0 && (
+                        <ul className="text-xs text-gray-600 space-y-1 border-t border-purple-100 pt-2">
+                          {pendingAdds.map((p, i) => (
+                            <li key={i}>
+                              + {p.name} ({p.data_type})
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setConfirmAddOpen(true)}
+                        disabled={pendingAdds.length === 0 || busy}
+                        className="w-full inline-flex items-center justify-center gap-2 rounded-lg border border-purple-700 bg-white px-3 py-2 text-sm font-medium text-purple-900 hover:bg-purple-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        {busyOp === "applyingAdds" && (
+                          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                        )}
+                        Create columns
+                      </button>
+                    </div>
+                  </div>
                 )}
-              >
-                Apply changes
-              </button>
+              </section>
             )}
           </div>
         </div>
       </div>
 
-      {confirmOpen && (
+      {confirmAddOpen && (
         <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black/50">
           <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-4 space-y-3">
-            <h3 className="font-semibold text-gray-900">
-              Confirm schema changes
-            </h3>
+            <h3 className="font-semibold text-gray-900">Create new columns</h3>
+            <p className="text-sm text-amber-900 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+              These columns will be added to the database and will appear in the
+              volunteers table for <span className="font-medium">every</span>{" "}
+              signed-in user (admins and staff), not only for you.
+            </p>
             <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1 max-h-48 overflow-y-auto">
               {pendingAdds.map((p, i) => (
                 <li key={`a-${i}`}>
                   Add column &quot;{p.name}&quot; ({p.data_type})
                 </li>
               ))}
+            </ul>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="px-3 py-1.5 text-sm rounded-lg border border-gray-300"
+                onClick={() => setConfirmAddOpen(false)}
+                disabled={busyOp === "applyingAdds"}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1.5 text-sm rounded-lg bg-purple-600 text-white disabled:opacity-50 inline-flex items-center gap-2 hover:bg-purple-700"
+                onClick={() => void runApplyAdds()}
+                disabled={busyOp === "applyingAdds"}
+              >
+                {busyOp === "applyingAdds" && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                Create columns
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirmDeleteOpen && (
+        <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black/50">
+          <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-4 space-y-3">
+            <h3 className="font-semibold text-gray-900">Remove columns</h3>
+            <p className="text-sm text-gray-600">
+              The following custom columns will be permanently removed from the
+              database.
+            </p>
+            <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1 max-h-48 overflow-y-auto">
               {pendingDeleteIds.map((id) => {
                 const c = customColumns.find((x) => x.id === id);
                 return (
@@ -665,19 +866,21 @@ export const ManageColumnsModal = ({
               <button
                 type="button"
                 className="px-3 py-1.5 text-sm rounded-lg border border-gray-300"
-                onClick={() => setConfirmOpen(false)}
-                disabled={applying}
+                onClick={() => setConfirmDeleteOpen(false)}
+                disabled={busyOp === "applyingDeletes"}
               >
                 Cancel
               </button>
               <button
                 type="button"
-                className="px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white disabled:opacity-50 inline-flex items-center gap-2"
-                onClick={() => void runApply()}
-                disabled={applying}
+                className="px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white disabled:opacity-50 inline-flex items-center gap-2 hover:bg-red-700"
+                onClick={() => void runApplyDeletes()}
+                disabled={busyOp === "applyingDeletes"}
               >
-                {applying && <Loader2 className="h-4 w-4 animate-spin" />}
-                Confirm
+                {busyOp === "applyingDeletes" && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                Remove columns
               </button>
             </div>
           </div>

--- a/src/components/volunteers/ManageTagsModal.tsx
+++ b/src/components/volunteers/ManageTagsModal.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from "react";
 import { Tags, X } from "lucide-react";
 import { ManageTagsContent } from "@/components/settings/ManageTagsContent";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
 import type { CohortRow, RoleRow } from "./types";
 
 interface ManageTagsModalProps {
@@ -11,6 +12,7 @@ interface ManageTagsModalProps {
   roles: RoleRow[];
   cohorts: CohortRow[];
   onRefresh: () => void;
+  customColumns?: CustomColumnRow[];
 }
 
 export function ManageTagsModal({
@@ -19,6 +21,7 @@ export function ManageTagsModal({
   roles,
   cohorts,
   onRefresh,
+  customColumns = [],
 }: ManageTagsModalProps): React.JSX.Element | null {
   useEffect(() => {
     if (!isOpen) return;
@@ -63,8 +66,8 @@ export function ManageTagsModal({
                   id="manage-tags-modal-desc"
                   className="text-sm text-gray-600 mt-1.5 leading-relaxed max-w-xl"
                 >
-                  Edit role names and cohort terms used in filters, imports, and
-                  the spreadsheet editor.
+                  Edit role names, cohort terms, and custom tag column options
+                  used in filters, imports, and the spreadsheet editor.
                 </p>
               </div>
             </div>
@@ -81,9 +84,11 @@ export function ManageTagsModal({
             <ManageTagsContent
               initialRoles={roles}
               initialCohorts={cohorts}
+              initialCustomTagColumns={customColumns}
               loadError={null}
               onRefresh={onRefresh}
               embedded
+              defaultCollapsed
             />
           </div>
         </div>

--- a/src/components/volunteers/SortModal.tsx
+++ b/src/components/volunteers/SortModal.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { Trash2, Plus } from "lucide-react";
 import clsx from "clsx";
 import { COLUMNS_CONFIG } from "./volunteerColumns";
+import type { SelectorColumn } from "./ColumnSelector";
 import { SortingState } from "@tanstack/react-table";
 import { ColumnSelector } from "./ColumnSelector";
 import { fixedPanelLeftPx } from "./FilterModal";
@@ -12,6 +13,8 @@ interface SortModalProps {
   onClose: () => void;
   sorting: SortingState;
   setSorting: React.Dispatch<React.SetStateAction<SortingState>>;
+  /** Columns available for sorting (defaults to built-in table columns). */
+  sortableColumns?: SelectorColumn[];
   alignRight?: boolean;
   /** When set, panel uses `position:fixed` so it is not clipped/misplaced inside scroll parents. */
   anchorRect?: DOMRectReadOnly | null;
@@ -22,9 +25,17 @@ export const SortModal = ({
   onClose,
   sorting,
   setSorting,
+  sortableColumns: sortableColumnsProp,
   alignRight = false,
   anchorRect = null,
 }: SortModalProps): React.JSX.Element | null => {
+  const sortableColumns: SelectorColumn[] =
+    sortableColumnsProp ??
+    COLUMNS_CONFIG.map((c) => ({
+      id: String(c.id),
+      label: c.label,
+      icon: c.icon,
+    }));
   const [editingIndex, setEditingIndex] = useState<number | "NEW" | null>(null);
 
   useEffect(() => {
@@ -70,13 +81,13 @@ export const SortModal = ({
     setEditingIndex(null);
   };
 
-  const availableColumns = COLUMNS_CONFIG.filter((col) => {
+  const availableColumns = sortableColumns.filter((col) => {
     const existingSortIndex = sorting.findIndex((s) => s.id === col.id);
     if (existingSortIndex === -1) return true;
     if (editingIndex !== "NEW" && existingSortIndex === editingIndex)
       return true;
     return false;
-  }).map((c) => ({ id: c.id as string, label: c.label, icon: c.icon }));
+  });
 
   return (
     <>
@@ -108,7 +119,7 @@ export const SortModal = ({
           <>
             <div className="flex flex-col gap-2">
               {sorting.map((sort, index) => {
-                const colDef = COLUMNS_CONFIG.find((c) => c.id === sort.id);
+                const colDef = sortableColumns.find((c) => c.id === sort.id);
                 const Icon = colDef?.icon;
                 return (
                   <div key={sort.id} className="flex items-center gap-2">

--- a/src/components/volunteers/TableToolbar.tsx
+++ b/src/components/volunteers/TableToolbar.tsx
@@ -485,7 +485,7 @@ export const TableToolbar = ({
           </div>
         )}
 
-        {role === "admin" && (hasEdits || canUndo || canRedo) && (
+        {(hasEdits || canUndo || canRedo) && (
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 animate-in fade-in slide-in-from-right-2 duration-200">
             <div className="flex items-center gap-0.5">
               <button

--- a/src/components/volunteers/TableToolbar.tsx
+++ b/src/components/volunteers/TableToolbar.tsx
@@ -23,6 +23,9 @@ import { FilterModal, filterModalAlignRight } from "./FilterModal";
 import { SortModal } from "./SortModal";
 import { SortingState } from "@tanstack/react-table";
 import type { CopyCellFormat } from "./copySelectedCells";
+import type { FilterableColumnDesc } from "./volunteerColumns";
+import type { SelectorColumn } from "./ColumnSelector";
+import { Columns3 } from "lucide-react";
 
 interface TableToolbarProps {
   globalFilter: string;
@@ -32,6 +35,9 @@ interface TableToolbarProps {
   sorting: SortingState;
   setSorting: React.Dispatch<React.SetStateAction<SortingState>>;
   filterOptions: Record<string, string[]>;
+  filterableColumns: FilterableColumnDesc[];
+  sortableColumns: SelectorColumn[];
+  onOpenManageColumns: () => void;
   role: string | null;
   selectedCount: number;
   isDeleting: boolean;
@@ -64,6 +70,9 @@ export const TableToolbar = ({
   sorting,
   setSorting,
   filterOptions,
+  filterableColumns,
+  sortableColumns,
+  onOpenManageColumns,
   role,
   selectedCount,
   isDeleting,
@@ -264,6 +273,7 @@ export const TableToolbar = ({
                   setFilterAnchorRect(null);
                 }}
                 optionsData={filterOptions}
+                filterableColumns={filterableColumns}
                 alignRight={mainFilterAlignRight}
                 anchorRect={isMainFilterOpen ? filterAnchorRect : null}
               />
@@ -312,12 +322,23 @@ export const TableToolbar = ({
                 }}
                 sorting={sorting}
                 setSorting={setSorting}
+                sortableColumns={sortableColumns}
                 alignRight={sortModalAlignRight}
                 anchorRect={isSortModalOpen ? sortAnchorRect : null}
               />
             </div>
 
-            {role === "admin" && !hasEdits && (
+            <button
+              type="button"
+              onClick={onOpenManageColumns}
+              className={neutralBtn}
+              aria-label="Manage table columns"
+            >
+              <Columns3 className="h-4 w-4 shrink-0" />
+              <span className="whitespace-nowrap">Columns</span>
+            </button>
+
+            {role === "admin" && (
               <button
                 type="button"
                 onClick={onOpenShortcuts}

--- a/src/components/volunteers/TableToolbar.tsx
+++ b/src/components/volunteers/TableToolbar.tsx
@@ -485,7 +485,7 @@ export const TableToolbar = ({
           </div>
         )}
 
-        {(hasEdits || canUndo || canRedo) && (
+        {role === "admin" && (hasEdits || canUndo || canRedo) && (
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 animate-in fade-in slide-in-from-right-2 duration-200">
             <div className="flex items-center gap-0.5">
               <button

--- a/src/components/volunteers/VolunteerTag.tsx
+++ b/src/components/volunteers/VolunteerTag.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import { getTagColorClass } from "./utils";
+import { getTagBackgroundColor } from "./utils";
 import clsx from "clsx";
 
 export const VolunteerTag = ({
@@ -13,9 +13,9 @@ export const VolunteerTag = ({
 
   return (
     <span
+      style={{ backgroundColor: getTagBackgroundColor(label) }}
       className={clsx(
         "px-2 py-0.5 rounded text-xs font-medium inline-flex items-center gap-1",
-        getTagColorClass(label),
         "text-gray-800"
       )}
     >

--- a/src/components/volunteers/VolunteersTable.tsx
+++ b/src/components/volunteers/VolunteersTable.tsx
@@ -26,6 +26,7 @@ import {
   buildFilterableColumnList,
   COLUMNS_CONFIG,
   customColumnIcon,
+  orderedColumnIds,
   parseCustomColumnTableId,
   tableIdForCustomColumn,
 } from "./volunteerColumns";
@@ -145,7 +146,12 @@ const VolunteersTableContent = ({
   const [columnPrefs, setColumnPrefs] = useState<{
     column_order: string[];
     hidden_columns: string[];
-  }>({ column_order: [], hidden_columns: [] });
+    prefs_updated_at: string | null;
+  }>({
+    column_order: [],
+    hidden_columns: [],
+    prefs_updated_at: null,
+  });
   const [columnOrder, setColumnOrder] = useState<string[]>([]);
 
   const refreshColumnMeta = useCallback(async (): Promise<void> => {
@@ -175,19 +181,17 @@ const VolunteersTableContent = ({
       setColumnOrder(fallback);
       return;
     }
-    const dataIds = new Set([...builtIn, ...customIds]);
-    const seen = new Set<string>();
-    const ordered: string[] = ["select"];
-    for (const id of columnPrefs.column_order) {
-      if (id === "select" || !dataIds.has(id) || seen.has(id)) continue;
-      seen.add(id);
-      ordered.push(id);
-    }
-    for (const id of [...builtIn, ...customIds]) {
-      if (!seen.has(id)) ordered.push(id);
-    }
-    setColumnOrder(ordered);
-  }, [customColumns, columnPrefs.column_order]);
+    const savedSansSelect = columnPrefs.column_order.filter(
+      (id) => id !== "select"
+    );
+    const merged = orderedColumnIds(
+      builtIn,
+      customColumns,
+      savedSansSelect,
+      columnPrefs.prefs_updated_at
+    );
+    setColumnOrder(["select", ...merged.filter((id) => id !== "select")]);
+  }, [customColumns, columnPrefs.column_order, columnPrefs.prefs_updated_at]);
 
   const {
     data,
@@ -347,9 +351,7 @@ const VolunteersTableContent = ({
               if (v) options[col.id]?.add(String(v));
             });
           } else if (value != null) {
-            if (col.id === "opt_in_communication")
-              options[col.id]?.add(value ? "Yes" : "No");
-            else options[col.id]?.add(String(value));
+            addScalarToOptionsBucket(col.id, ck, value);
           }
         }
       });
@@ -357,6 +359,29 @@ const VolunteersTableContent = ({
 
     for (const edits of Object.values(editedRows)) {
       for (const [colId, value] of Object.entries(edits)) {
+        if (
+          colId === "custom_data" &&
+          value &&
+          typeof value === "object" &&
+          !Array.isArray(value)
+        ) {
+          for (const [key, v] of Object.entries(
+            value as Record<string, unknown>
+          )) {
+            const fid = tableIdForCustomColumn(key);
+            const bucket = options[fid];
+            if (!bucket) continue;
+            if (Array.isArray(v)) {
+              v.forEach((x) => {
+                if (x) bucket.add(String(x));
+              });
+            } else if (v != null) {
+              addScalarToOptionsBucket(fid, key, v);
+            }
+          }
+          continue;
+        }
+
         const bucket = options[colId];
         if (!bucket) continue;
         if (Array.isArray(value)) {
@@ -364,9 +389,8 @@ const VolunteersTableContent = ({
             if (v) bucket.add(String(v));
           });
         } else if (value != null) {
-          if (colId === "opt_in_communication")
-            bucket.add(value ? "Yes" : "No");
-          else bucket.add(String(value));
+          const ck = parseCustomColumnTableId(colId);
+          addScalarToOptionsBucket(colId, ck, value);
         }
       }
     }
@@ -390,6 +414,26 @@ const VolunteersTableContent = ({
           if (idxB === -1) return -1;
           return idxA - idxB;
         });
+      } else if (
+        customColumns.some(
+          (c) =>
+            c.data_type === "tag" &&
+            tableIdForCustomColumn(c.column_key) === key
+        )
+      ) {
+        const tagOrder = customTagOptionOrder[key] ?? [];
+        if (tagOrder.length > 0) {
+          result[key] = arr.sort((a, b) => {
+            const idxA = tagOrder.indexOf(a);
+            const idxB = tagOrder.indexOf(b);
+            if (idxA === -1 && idxB === -1) return a.localeCompare(b);
+            if (idxA === -1) return 1;
+            if (idxB === -1) return -1;
+            return idxA - idxB;
+          });
+        } else {
+          result[key] = arr.sort((a, b) => a.localeCompare(b));
+        }
       } else if (key === "cohorts") {
         result[key] = arr.sort(sortCohorts);
       } else {
@@ -1181,6 +1225,7 @@ const VolunteersTableContent = ({
         isOpen={isAddVolunteerOpen}
         onClose={() => setIsAddVolunteerOpen(false)}
         optionsData={filterOptions}
+        customColumns={customColumns}
         onSuccess={() => {
           toast.success("Volunteer added");
           setLoading(true);
@@ -1230,11 +1275,16 @@ const VolunteersTableContent = ({
 
       <ManageColumnsModal
         isOpen={isManageColumnsOpen}
-        onClose={() => setIsManageColumnsOpen(false)}
+        onClose={() => {
+          setIsManageColumnsOpen(false);
+          void refreshColumnMeta();
+        }}
         isAdmin={isAdmin}
         customColumns={customColumns}
         columnOrder={columnPrefs.column_order}
         hiddenColumns={columnPrefs.hidden_columns}
+        prefsUpdatedAt={columnPrefs.prefs_updated_at}
+        onPreferencesSaved={refreshColumnMeta}
         onApplied={async () => {
           await refreshColumnMeta();
           setLoading(true);

--- a/src/components/volunteers/VolunteersTable.tsx
+++ b/src/components/volunteers/VolunteersTable.tsx
@@ -31,9 +31,11 @@ import {
   tableIdForCustomColumn,
 } from "./volunteerColumns";
 import type { CustomColumnRow } from "@/lib/api/customColumns";
+import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
 import {
   getCustomColumnsAction,
   getColumnPreferencesAction,
+  getVolunteerTableGlobalSettingsAction,
 } from "@/lib/api/actions";
 import { ManageColumnsModal } from "./ManageColumnsModal";
 import { AlertCircle } from "lucide-react";
@@ -153,19 +155,37 @@ const VolunteersTableContent = ({
     prefs_updated_at: null,
   });
   const [columnOrder, setColumnOrder] = useState<string[]>([]);
+  const [adminHiddenColumns, setAdminHiddenColumns] = useState<string[]>([]);
 
   const refreshColumnMeta = useCallback(async (): Promise<void> => {
     try {
-      const [cols, prefs] = await Promise.all([
+      const [cols, prefs, global] = await Promise.all([
         getCustomColumnsAction(),
         getColumnPreferencesAction(),
+        getVolunteerTableGlobalSettingsAction(),
       ]);
       setCustomColumns(cols);
       setColumnPrefs(prefs);
+      setAdminHiddenColumns(global.admin_hidden_columns);
     } catch (e) {
       console.error("[VolunteersTable] column meta fetch failed:", e);
     }
   }, []);
+
+  const globalHiddenSet = useMemo(
+    () => new Set(adminHiddenColumns),
+    [adminHiddenColumns]
+  );
+
+  const effectiveColumnPrefs = useMemo(
+    () => ({
+      ...columnPrefs,
+      hidden_columns: sanitizeHiddenColumnIds([
+        ...new Set([...columnPrefs.hidden_columns, ...adminHiddenColumns]),
+      ]).sort(),
+    }),
+    [columnPrefs, adminHiddenColumns]
+  );
 
   useEffect(() => {
     void refreshColumnMeta();
@@ -247,24 +267,28 @@ const VolunteersTableContent = ({
   });
 
   const filterableColumnList = useMemo(
-    () => buildFilterableColumnList(customColumns),
-    [customColumns]
+    () =>
+      buildFilterableColumnList(customColumns).filter(
+        (c) => !globalHiddenSet.has(c.id)
+      ),
+    [customColumns, globalHiddenSet]
   );
 
   const sortableColumnOptions = useMemo(
-    () => [
-      ...COLUMNS_CONFIG.map((c) => ({
-        id: String(c.id),
-        label: c.label,
-        icon: c.icon,
-      })),
-      ...customColumns.map((c) => ({
-        id: tableIdForCustomColumn(c.column_key),
-        label: c.name,
-        icon: customColumnIcon(c.data_type),
-      })),
-    ],
-    [customColumns]
+    () =>
+      [
+        ...COLUMNS_CONFIG.map((c) => ({
+          id: String(c.id),
+          label: c.label,
+          icon: c.icon,
+        })),
+        ...customColumns.map((c) => ({
+          id: tableIdForCustomColumn(c.column_key),
+          label: c.name,
+          icon: customColumnIcon(c.data_type),
+        })),
+      ].filter((c) => !globalHiddenSet.has(c.id)),
+    [customColumns, globalHiddenSet]
   );
 
   const filterOptions = useMemo(() => {
@@ -570,13 +594,19 @@ const VolunteersTableContent = ({
       },
       ...buildDynamicColumns(
         customColumns,
-        columnPrefs,
+        effectiveColumnPrefs,
         isAdmin,
         handleCellEdit,
         filterOptions
       ),
     ],
-    [customColumns, columnPrefs, isAdmin, handleCellEdit, filterOptions]
+    [
+      customColumns,
+      effectiveColumnPrefs,
+      isAdmin,
+      handleCellEdit,
+      filterOptions,
+    ]
   );
 
   const table = useReactTable({
@@ -1284,6 +1314,7 @@ const VolunteersTableContent = ({
         columnOrder={columnPrefs.column_order}
         hiddenColumns={columnPrefs.hidden_columns}
         prefsUpdatedAt={columnPrefs.prefs_updated_at}
+        globalHiddenColumnIds={adminHiddenColumns}
         onPreferencesSaved={refreshColumnMeta}
         onApplied={async () => {
           await refreshColumnMeta();

--- a/src/components/volunteers/VolunteersTable.tsx
+++ b/src/components/volunteers/VolunteersTable.tsx
@@ -22,10 +22,19 @@ import toast from "react-hot-toast";
 import type { Volunteer } from "./types";
 import { useCellSelection } from "./useCellSelection";
 import {
-  getBaseColumns,
-  FILTERABLE_COLUMNS,
+  buildDynamicColumns,
+  buildFilterableColumnList,
   COLUMNS_CONFIG,
+  customColumnIcon,
+  parseCustomColumnTableId,
+  tableIdForCustomColumn,
 } from "./volunteerColumns";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
+import {
+  getCustomColumnsAction,
+  getColumnPreferencesAction,
+} from "@/lib/api/actions";
+import { ManageColumnsModal } from "./ManageColumnsModal";
 import { AlertCircle } from "lucide-react";
 import { FilterBar } from "./FilterBar";
 import { TableToolbar } from "./TableToolbar";
@@ -66,11 +75,23 @@ type PendingRowChange = {
   changes: PendingCellChange[];
 };
 
-const formatPendingValue = (colId: string, value: unknown): string => {
+const formatPendingValue = (
+  colId: string,
+  value: unknown,
+  customColumns: CustomColumnRow[]
+): string => {
   if (value === null || value === undefined || value === "") return "(empty)";
   if (colId === "opt_in_communication") {
     if (value === true) return "Yes";
     if (value === false) return "No";
+  }
+  const ck = parseCustomColumnTableId(colId);
+  if (ck) {
+    const def = customColumns.find((c) => c.column_key === ck);
+    if (def?.data_type === "boolean") {
+      if (value === true) return "Yes";
+      if (value === false) return "No";
+    }
   }
   if (Array.isArray(value)) {
     return value.length > 0 ? value.map(String).join(", ") : "(empty)";
@@ -119,6 +140,54 @@ const VolunteersTableContent = ({
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isChangesModalOpen, setIsChangesModalOpen] = useState(false);
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+  const [isManageColumnsOpen, setIsManageColumnsOpen] = useState(false);
+  const [customColumns, setCustomColumns] = useState<CustomColumnRow[]>([]);
+  const [columnPrefs, setColumnPrefs] = useState<{
+    column_order: string[];
+    hidden_columns: string[];
+  }>({ column_order: [], hidden_columns: [] });
+  const [columnOrder, setColumnOrder] = useState<string[]>([]);
+
+  const refreshColumnMeta = useCallback(async (): Promise<void> => {
+    try {
+      const [cols, prefs] = await Promise.all([
+        getCustomColumnsAction(),
+        getColumnPreferencesAction(),
+      ]);
+      setCustomColumns(cols);
+      setColumnPrefs(prefs);
+    } catch (e) {
+      console.error("[VolunteersTable] column meta fetch failed:", e);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshColumnMeta();
+  }, [refreshColumnMeta]);
+
+  useEffect(() => {
+    const builtIn = COLUMNS_CONFIG.map((c) => String(c.id));
+    const customIds = customColumns.map((c) =>
+      tableIdForCustomColumn(c.column_key)
+    );
+    const fallback = ["select", ...builtIn, ...customIds];
+    if (columnPrefs.column_order.length === 0) {
+      setColumnOrder(fallback);
+      return;
+    }
+    const dataIds = new Set([...builtIn, ...customIds]);
+    const seen = new Set<string>();
+    const ordered: string[] = ["select"];
+    for (const id of columnPrefs.column_order) {
+      if (id === "select" || !dataIds.has(id) || seen.has(id)) continue;
+      seen.add(id);
+      ordered.push(id);
+    }
+    for (const id of [...builtIn, ...customIds]) {
+      if (!seen.has(id)) ordered.push(id);
+    }
+    setColumnOrder(ordered);
+  }, [customColumns, columnPrefs.column_order]);
 
   const {
     data,
@@ -164,6 +233,7 @@ const VolunteersTableContent = ({
     allVolunteers,
     allRoles,
     allCohorts,
+    customColumns,
     setData,
     setAllVolunteers,
     bumpDisplayRefresh,
@@ -172,9 +242,67 @@ const VolunteersTableContent = ({
     syncedEditedRowsRef: editedRowsRef,
   });
 
+  const filterableColumnList = useMemo(
+    () => buildFilterableColumnList(customColumns),
+    [customColumns]
+  );
+
+  const sortableColumnOptions = useMemo(
+    () => [
+      ...COLUMNS_CONFIG.map((c) => ({
+        id: String(c.id),
+        label: c.label,
+        icon: c.icon,
+      })),
+      ...customColumns.map((c) => ({
+        id: tableIdForCustomColumn(c.column_key),
+        label: c.name,
+        icon: customColumnIcon(c.data_type),
+      })),
+    ],
+    [customColumns]
+  );
+
   const filterOptions = useMemo(() => {
     const options: Record<string, Set<string>> = {};
-    FILTERABLE_COLUMNS.forEach((col) => {
+    const customTagOptionOrder: Record<string, string[]> = {};
+    customColumns.forEach((c) => {
+      if (c.data_type === "tag") {
+        customTagOptionOrder[tableIdForCustomColumn(c.column_key)] = [
+          ...(c.tag_options ?? []),
+        ];
+      }
+    });
+
+    const addScalarToOptionsBucket = (
+      colId: string,
+      ck: string | null,
+      raw: unknown
+    ): void => {
+      const bucket = options[colId];
+      if (!bucket || raw == null) return;
+      if (colId === "opt_in_communication") {
+        bucket.add(raw ? "Yes" : "No");
+        return;
+      }
+      if (ck) {
+        const def = customColumns.find((c) => c.column_key === ck);
+        if (def?.data_type === "boolean") {
+          if (typeof raw === "boolean") {
+            bucket.add(raw ? "Yes" : "No");
+          } else {
+            const s = String(raw).toLowerCase();
+            if (s === "true") bucket.add("Yes");
+            else if (s === "false") bucket.add("No");
+            else bucket.add(String(raw));
+          }
+          return;
+        }
+      }
+      bucket.add(String(raw));
+    };
+
+    filterableColumnList.forEach((col) => {
       if (col.type === "options") options[col.id] = new Set();
     });
 
@@ -192,10 +320,28 @@ const VolunteersTableContent = ({
     PRONOUN_OPTIONS.forEach((p) => options["pronouns"]?.add(p));
     OPT_IN_OPTIONS.forEach((o) => options["opt_in_communication"]?.add(o));
 
+    customColumns.forEach((c) => {
+      const fid = tableIdForCustomColumn(c.column_key);
+      if (c.data_type === "boolean") {
+        options[fid]?.add("Yes");
+        options[fid]?.add("No");
+      }
+      if (c.data_type === "tag" && (c.tag_options?.length ?? 0) > 0) {
+        c.tag_options?.forEach((t) => options[fid]?.add(t));
+      }
+    });
+
     allVolunteers.forEach((volunteer) => {
-      FILTERABLE_COLUMNS.forEach((col) => {
+      filterableColumnList.forEach((col) => {
         if (col.type === "options") {
-          const value = volunteer[col.id as keyof Volunteer];
+          const ck = parseCustomColumnTableId(col.id);
+          const value = ck
+            ? volunteer.custom_data &&
+              typeof volunteer.custom_data === "object" &&
+              !Array.isArray(volunteer.custom_data)
+              ? (volunteer.custom_data as Record<string, unknown>)[ck]
+              : undefined
+            : volunteer[col.id as keyof Volunteer];
           if (Array.isArray(value)) {
             value.forEach((v) => {
               if (v) options[col.id]?.add(String(v));
@@ -251,7 +397,14 @@ const VolunteersTableContent = ({
       }
     }
     return result;
-  }, [allVolunteers, allRoles, allCohorts, editedRows]);
+  }, [
+    allVolunteers,
+    allRoles,
+    allCohorts,
+    editedRows,
+    filterableColumnList,
+    customColumns,
+  ]);
 
   const pendingChanges = useMemo<PendingRowChange[]>(() => {
     return Object.entries(editedRows)
@@ -263,18 +416,66 @@ const VolunteersTableContent = ({
         const volunteerLabel =
           original.name_org?.trim() || original.pseudonym?.trim() || `ID ${id}`;
 
-        const changes: PendingCellChange[] = Object.entries(partial).map(
+        const changes: PendingCellChange[] = Object.entries(partial).flatMap(
           ([colId, nextValue]) => {
+            if (
+              colId === "custom_data" &&
+              nextValue &&
+              typeof nextValue === "object"
+            ) {
+              const m = nextValue as Record<string, unknown>;
+              const origCd =
+                original.custom_data &&
+                typeof original.custom_data === "object" &&
+                !Array.isArray(original.custom_data)
+                  ? (original.custom_data as Record<string, unknown>)
+                  : {};
+              const keys = new Set([...Object.keys(origCd), ...Object.keys(m)]);
+              const rows: PendingCellChange[] = [];
+              for (const key of keys) {
+                const ov = origCd[key];
+                const nv = m[key];
+                const same =
+                  Array.isArray(ov) && Array.isArray(nv)
+                    ? JSON.stringify([...ov].sort()) ===
+                      JSON.stringify([...nv].sort())
+                    : ov === nv;
+                if (same) continue;
+                const tid = tableIdForCustomColumn(key);
+                const cc = customColumns.find((c) => c.column_key === key);
+                rows.push({
+                  colId: tid,
+                  label: cc?.name ?? key,
+                  from: formatPendingValue(tid, ov, customColumns),
+                  to: formatPendingValue(tid, nv, customColumns),
+                });
+              }
+              return rows;
+            }
             const colLabel =
               COLUMNS_CONFIG.find((c) => String(c.id) === colId)?.label ??
+              customColumns.find(
+                (c) => tableIdForCustomColumn(c.column_key) === colId
+              )?.name ??
               colId;
-            const prevValue = original[colId as keyof Volunteer];
-            return {
-              colId,
-              label: colLabel,
-              from: formatPendingValue(colId, prevValue),
-              to: formatPendingValue(colId, nextValue),
-            };
+            const prevValue =
+              parseCustomColumnTableId(colId) !== null
+                ? original.custom_data &&
+                  typeof original.custom_data === "object" &&
+                  !Array.isArray(original.custom_data)
+                  ? (original.custom_data as Record<string, unknown>)[
+                      parseCustomColumnTableId(colId)!
+                    ]
+                  : undefined
+                : original[colId as keyof Volunteer];
+            return [
+              {
+                colId,
+                label: colLabel,
+                from: formatPendingValue(colId, prevValue, customColumns),
+                to: formatPendingValue(colId, nextValue, customColumns),
+              },
+            ];
           }
         );
 
@@ -283,7 +484,7 @@ const VolunteersTableContent = ({
       })
       .filter((row): row is PendingRowChange => row !== null)
       .sort((a, b) => a.volunteerLabel.localeCompare(b.volunteerLabel));
-  }, [editedRows, allVolunteers]);
+  }, [editedRows, allVolunteers, customColumns]);
 
   const pendingChangesCount = useMemo(
     () => pendingChanges.reduce((acc, row) => acc + row.changes.length, 0),
@@ -323,9 +524,15 @@ const VolunteersTableContent = ({
         enableSorting: false,
         enableResizing: false,
       },
-      ...getBaseColumns(isAdmin, handleCellEdit, filterOptions),
+      ...buildDynamicColumns(
+        customColumns,
+        columnPrefs,
+        isAdmin,
+        handleCellEdit,
+        filterOptions
+      ),
     ],
-    [isAdmin, handleCellEdit, filterOptions]
+    [customColumns, columnPrefs, isAdmin, handleCellEdit, filterOptions]
   );
 
   const table = useReactTable({
@@ -334,7 +541,13 @@ const VolunteersTableContent = ({
     /** Stable row identity avoids reusing row DOM/state when sort/page changes (default ids are row indices). */
     getRowId: (row) => String(row.id),
     columnResizeMode: "onChange",
-    state: { sorting, rowSelection, globalFilter: debouncedGlobalFilter },
+    state: {
+      sorting,
+      rowSelection,
+      globalFilter: debouncedGlobalFilter,
+      columnOrder,
+    },
+    onColumnOrderChange: setColumnOrder,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -395,12 +608,23 @@ const VolunteersTableContent = ({
     selectedCellCount,
     copySelectedCells,
   } = useCellSelection(table);
-  const clearValueForColumn = useCallback((colId: string): unknown => {
-    const col = COLUMNS_CONFIG.find((c) => String(c.id) === colId);
-    if (!col) return "";
-    if (col.filterType === "options") return col.isMulti ? [] : null;
-    return "";
-  }, []);
+  const clearValueForColumn = useCallback(
+    (colId: string): unknown => {
+      const ck = parseCustomColumnTableId(colId);
+      if (ck) {
+        const def = customColumns.find((c) => c.column_key === ck);
+        if (def?.data_type === "tag") return def.is_multi ? [] : null;
+        if (def?.data_type === "boolean") return null;
+        if (def?.data_type === "number") return null;
+        return "";
+      }
+      const col = COLUMNS_CONFIG.find((c) => String(c.id) === colId);
+      if (!col) return "";
+      if (col.filterType === "options") return col.isMulti ? [] : null;
+      return "";
+    },
+    [customColumns]
+  );
 
   const clearSelectedCells = useCallback((): void => {
     const selectedIds = Object.keys(selectedCells).filter(
@@ -701,6 +925,9 @@ const VolunteersTableContent = ({
             sorting={sorting}
             setSorting={setSorting}
             filterOptions={filterOptions}
+            filterableColumns={filterableColumnList}
+            sortableColumns={sortableColumnOptions}
+            onOpenManageColumns={() => setIsManageColumnsOpen(true)}
             role={role}
             selectedCount={selectedRowIds.length}
             isDeleting={isDeleting}
@@ -731,6 +958,7 @@ const VolunteersTableContent = ({
               globalOp={globalOp}
               setGlobalOp={setGlobalOp}
               optionsData={filterOptions}
+              filterableColumns={filterableColumnList}
               sorting={sorting}
               setSorting={setSorting}
             />
@@ -861,10 +1089,23 @@ const VolunteersTableContent = ({
                           cell.column.id
                         );
                         const isSelectColumn = cell.column.id === "select";
+                        const edit = editedRows[row.original.id];
+                        const customKey = parseCustomColumnTableId(
+                          cell.column.id
+                        );
                         const isModified =
-                          editedRows[row.original.id]?.[
-                            cell.column.id as keyof Volunteer
-                          ] !== undefined;
+                          edit !== undefined &&
+                          (customKey
+                            ? edit.custom_data !== undefined &&
+                              typeof edit.custom_data === "object" &&
+                              !Array.isArray(edit.custom_data) &&
+                              Object.prototype.hasOwnProperty.call(
+                                edit.custom_data as object,
+                                customKey
+                              )
+                            : (edit as Record<string, unknown>)[
+                                cell.column.id
+                              ] !== undefined);
 
                         const topRow = rows[rowIndex - 1];
                         const bottomRow = rows[rowIndex + 1];
@@ -984,6 +1225,20 @@ const VolunteersTableContent = ({
         onRefresh={() => {
           setLoading(true);
           fetchInitialData();
+        }}
+      />
+
+      <ManageColumnsModal
+        isOpen={isManageColumnsOpen}
+        onClose={() => setIsManageColumnsOpen(false)}
+        isAdmin={isAdmin}
+        customColumns={customColumns}
+        columnOrder={columnPrefs.column_order}
+        hiddenColumns={columnPrefs.hidden_columns}
+        onApplied={async () => {
+          await refreshColumnMeta();
+          setLoading(true);
+          await fetchInitialData();
         }}
       />
 

--- a/src/components/volunteers/VolunteersTable.tsx
+++ b/src/components/volunteers/VolunteersTable.tsx
@@ -29,13 +29,16 @@ import {
   orderedColumnIds,
   parseCustomColumnTableId,
   tableIdForCustomColumn,
+  isCustomColumnCellModified,
 } from "./volunteerColumns";
 import type { CustomColumnRow } from "@/lib/api/customColumns";
 import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
+import { mergeCustomTagOptionsFromVolunteers } from "@/lib/volunteerTable/mergeCustomTagOptionsFromVolunteers";
 import {
   getCustomColumnsAction,
   getColumnPreferencesAction,
   getVolunteerTableGlobalSettingsAction,
+  saveColumnPreferencesAction,
 } from "@/lib/api/actions";
 import { ManageColumnsModal } from "./ManageColumnsModal";
 import { AlertCircle } from "lucide-react";
@@ -149,6 +152,8 @@ const VolunteersTableContent = ({
     column_order: string[];
     hidden_columns: string[];
     prefs_updated_at: string | null;
+    /** Staff: merged hidden for table rendering (includes org-wide hidden). */
+    hidden_columns_effective?: string[];
   }>({
     column_order: [],
     hidden_columns: [],
@@ -159,32 +164,49 @@ const VolunteersTableContent = ({
 
   const refreshColumnMeta = useCallback(async (): Promise<void> => {
     try {
-      const [cols, prefs, global] = await Promise.all([
-        getCustomColumnsAction(),
-        getColumnPreferencesAction(),
-        getVolunteerTableGlobalSettingsAction(),
-      ]);
-      setCustomColumns(cols);
-      setColumnPrefs(prefs);
-      setAdminHiddenColumns(global.admin_hidden_columns);
+      if (isAdmin) {
+        const [cols, prefs, global] = await Promise.all([
+          getCustomColumnsAction(),
+          getColumnPreferencesAction(),
+          getVolunteerTableGlobalSettingsAction(),
+        ]);
+        setCustomColumns(cols);
+        setColumnPrefs(prefs);
+        setAdminHiddenColumns(global.admin_hidden_columns);
+      } else {
+        const [cols, prefs] = await Promise.all([
+          getCustomColumnsAction(),
+          getColumnPreferencesAction(),
+        ]);
+        setCustomColumns(cols);
+        setColumnPrefs(prefs);
+        setAdminHiddenColumns([]);
+      }
     } catch (e) {
       console.error("[VolunteersTable] column meta fetch failed:", e);
     }
-  }, []);
+  }, [isAdmin]);
 
-  const globalHiddenSet = useMemo(
-    () => new Set(adminHiddenColumns),
-    [adminHiddenColumns]
-  );
-
-  const effectiveColumnPrefs = useMemo(
-    () => ({
+  const effectiveColumnPrefs = useMemo(() => {
+    if (isAdmin) {
+      return {
+        ...columnPrefs,
+        hidden_columns: sanitizeHiddenColumnIds([
+          ...new Set([...columnPrefs.hidden_columns, ...adminHiddenColumns]),
+        ]).sort(),
+      };
+    }
+    return {
       ...columnPrefs,
-      hidden_columns: sanitizeHiddenColumnIds([
-        ...new Set([...columnPrefs.hidden_columns, ...adminHiddenColumns]),
-      ]).sort(),
-    }),
-    [columnPrefs, adminHiddenColumns]
+      hidden_columns: sanitizeHiddenColumnIds(
+        columnPrefs.hidden_columns_effective ?? columnPrefs.hidden_columns
+      ),
+    };
+  }, [columnPrefs, adminHiddenColumns, isAdmin]);
+
+  const effectiveHiddenSet = useMemo(
+    () => new Set(effectiveColumnPrefs.hidden_columns),
+    [effectiveColumnPrefs.hidden_columns]
   );
 
   useEffect(() => {
@@ -201,6 +223,13 @@ const VolunteersTableContent = ({
       setColumnOrder(fallback);
       return;
     }
+    if (!isAdmin) {
+      const savedSansSelect = columnPrefs.column_order.filter(
+        (id) => id !== "select"
+      );
+      setColumnOrder(["select", ...savedSansSelect]);
+      return;
+    }
     const savedSansSelect = columnPrefs.column_order.filter(
       (id) => id !== "select"
     );
@@ -211,7 +240,65 @@ const VolunteersTableContent = ({
       columnPrefs.prefs_updated_at
     );
     setColumnOrder(["select", ...merged.filter((id) => id !== "select")]);
-  }, [customColumns, columnPrefs.column_order, columnPrefs.prefs_updated_at]);
+  }, [
+    customColumns,
+    columnPrefs.column_order,
+    columnPrefs.prefs_updated_at,
+    isAdmin,
+  ]);
+
+  const columnOrderRef = useRef(columnOrder);
+  columnOrderRef.current = columnOrder;
+  const columnPrefsRef = useRef(columnPrefs);
+  columnPrefsRef.current = columnPrefs;
+  const refreshColumnMetaRef = useRef(refreshColumnMeta);
+  refreshColumnMetaRef.current = refreshColumnMeta;
+  const persistColumnOrderTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+
+  /** Persist column order after header drag-reorder so it survives refresh and future logins (same as Save in Manage columns). */
+  useEffect(() => {
+    if (persistColumnOrderTimerRef.current) {
+      clearTimeout(persistColumnOrderTimerRef.current);
+      persistColumnOrderTimerRef.current = null;
+    }
+    if (columnOrder.length === 0) return;
+
+    const sansSelect = columnOrder.filter((id) => id !== "select");
+    const prefsOrder = columnPrefs.column_order.filter((id) => id !== "select");
+    if (JSON.stringify(sansSelect) === JSON.stringify(prefsOrder)) {
+      return;
+    }
+
+    persistColumnOrderTimerRef.current = setTimeout(() => {
+      persistColumnOrderTimerRef.current = null;
+      void (async (): Promise<void> => {
+        const latest = columnOrderRef.current.filter((id) => id !== "select");
+        const prefs = columnPrefsRef.current;
+        const prefsOrderNow = prefs.column_order.filter(
+          (id) => id !== "select"
+        );
+        if (JSON.stringify(latest) === JSON.stringify(prefsOrderNow)) return;
+        const res = await saveColumnPreferencesAction(
+          latest,
+          prefs.hidden_columns
+        );
+        if (res.success) {
+          await refreshColumnMetaRef.current();
+        } else {
+          toast.error(res.error ?? "Could not save column order");
+        }
+      })();
+    }, 500);
+
+    return (): void => {
+      if (persistColumnOrderTimerRef.current) {
+        clearTimeout(persistColumnOrderTimerRef.current);
+        persistColumnOrderTimerRef.current = null;
+      }
+    };
+  }, [columnOrder, columnPrefs.column_order]);
 
   const {
     data,
@@ -237,7 +324,7 @@ const VolunteersTableContent = ({
     refreshRolesAndCohorts,
     setAllVolunteers,
     debouncedFilters,
-  } = useVolunteersData({ isAdmin, editedRowsRef });
+  } = useVolunteersData({ isAdmin, editedRowsRef, editedRows });
 
   const {
     isSaving,
@@ -269,9 +356,9 @@ const VolunteersTableContent = ({
   const filterableColumnList = useMemo(
     () =>
       buildFilterableColumnList(customColumns).filter(
-        (c) => !globalHiddenSet.has(c.id)
+        (c) => !effectiveHiddenSet.has(c.id)
       ),
-    [customColumns, globalHiddenSet]
+    [customColumns, effectiveHiddenSet]
   );
 
   const sortableColumnOptions = useMemo(
@@ -287,8 +374,8 @@ const VolunteersTableContent = ({
           label: c.name,
           icon: customColumnIcon(c.data_type),
         })),
-      ].filter((c) => !globalHiddenSet.has(c.id)),
-    [customColumns, globalHiddenSet]
+      ].filter((c) => !effectiveHiddenSet.has(c.id)),
+    [customColumns, effectiveHiddenSet]
   );
 
   const filterOptions = useMemo(() => {
@@ -473,6 +560,17 @@ const VolunteersTableContent = ({
     filterableColumnList,
     customColumns,
   ]);
+
+  /** Tag presets + values that appear in volunteer data (cell-created tags) for Manage Tags. */
+  const customColumnsForManageTags = useMemo(
+    () =>
+      mergeCustomTagOptionsFromVolunteers(
+        customColumns,
+        allVolunteers,
+        editedRows
+      ),
+    [customColumns, allVolunteers, editedRows]
+  );
 
   const pendingChanges = useMemo<PendingRowChange[]>(() => {
     return Object.entries(editedRows)
@@ -1167,15 +1265,17 @@ const VolunteersTableContent = ({
                         const customKey = parseCustomColumnTableId(
                           cell.column.id
                         );
+                        /** Table `row.original` is merged with edits; compare custom cells to server baseline from `allVolunteers`. */
+                        const baselineRow =
+                          allVolunteers.find((v) => v.id === row.original.id) ??
+                          row.original;
                         const isModified =
                           edit !== undefined &&
                           (customKey
-                            ? edit.custom_data !== undefined &&
-                              typeof edit.custom_data === "object" &&
-                              !Array.isArray(edit.custom_data) &&
-                              Object.prototype.hasOwnProperty.call(
-                                edit.custom_data as object,
-                                customKey
+                            ? isCustomColumnCellModified(
+                                baselineRow,
+                                customKey,
+                                edit
                               )
                             : (edit as Record<string, unknown>)[
                                 cell.column.id
@@ -1256,6 +1356,7 @@ const VolunteersTableContent = ({
         onClose={() => setIsAddVolunteerOpen(false)}
         optionsData={filterOptions}
         customColumns={customColumns}
+        globalHiddenColumnIds={adminHiddenColumns}
         onSuccess={() => {
           toast.success("Volunteer added");
           setLoading(true);
@@ -1297,8 +1398,10 @@ const VolunteersTableContent = ({
         onClose={() => setIsManageTagsOpen(false)}
         roles={allRoles}
         cohorts={allCohorts}
+        customColumns={customColumnsForManageTags}
         onRefresh={() => {
           setLoading(true);
+          void refreshColumnMeta();
           fetchInitialData();
         }}
       />

--- a/src/components/volunteers/useVolunteerEdits.ts
+++ b/src/components/volunteers/useVolunteerEdits.ts
@@ -11,6 +11,7 @@ import type { CustomColumnRow } from "@/lib/api/customColumns";
 import {
   parseCustomColumnTableId,
   getVolunteerCustomDataMap,
+  editedCustomValueMatchesOriginal,
 } from "./volunteerColumns";
 
 interface UseVolunteerEditsProps {
@@ -59,6 +60,46 @@ export interface UseVolunteerEditsReturn {
 }
 
 const MAX_HISTORY = 100;
+
+/** Full custom_data map for a row: server baseline + any overlay already in editedRows. */
+function mergeCustomDataFromRow(
+  rowId: number,
+  rowObj: Record<string, unknown>,
+  allVolunteers: Volunteer[]
+): Record<string, unknown> {
+  const base = getVolunteerCustomDataMap(
+    allVolunteers.find((v) => v.id === rowId) || ({} as Volunteer)
+  );
+  const overlay =
+    typeof rowObj["custom_data"] === "object" &&
+    rowObj["custom_data"] !== null &&
+    !Array.isArray(rowObj["custom_data"])
+      ? (rowObj["custom_data"] as Record<string, unknown>)
+      : {};
+  return { ...base, ...overlay };
+}
+
+function customDataEquals(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    const va = a[k];
+    const vb = b[k];
+    if (Array.isArray(va) && Array.isArray(vb)) {
+      if (
+        JSON.stringify([...(va as unknown[])].sort()) !==
+        JSON.stringify([...(vb as unknown[])].sort())
+      ) {
+        return false;
+      }
+    } else if (va !== vb) {
+      return false;
+    }
+  }
+  return true;
+}
 
 const normalizeValue = (
   colId: string,
@@ -180,30 +221,7 @@ export const useVolunteerEdits = ({
       const customKey = parseCustomColumnTableId(colId);
       if (customKey && originalRow) {
         const originalValue = getVolunteerCustomDataMap(originalRow)[customKey];
-        if (Array.isArray(finalValue) && Array.isArray(originalValue)) {
-          return (
-            JSON.stringify([...(finalValue as string[])].sort()) ===
-            JSON.stringify([...(originalValue as string[])].sort())
-          );
-        }
-        if (Array.isArray(finalValue) || Array.isArray(originalValue)) {
-          return false;
-        }
-        if (
-          typeof finalValue === "boolean" ||
-          typeof originalValue === "boolean"
-        ) {
-          return finalValue === originalValue;
-        }
-        if (
-          typeof finalValue === "number" ||
-          typeof originalValue === "number"
-        ) {
-          return finalValue === originalValue;
-        }
-        const norm = (v: unknown): string =>
-          v === null || v === undefined ? "" : String(v);
-        return norm(finalValue) === norm(originalValue);
+        return editedCustomValueMatchesOriginal(originalValue, finalValue);
       }
 
       const originalValue = originalRow
@@ -243,16 +261,16 @@ export const useVolunteerEdits = ({
             if (next[rowId]) {
               const rowObj = { ...(next[rowId] as Record<string, unknown>) };
               if (ck) {
-                const cd = {
-                  ...(typeof rowObj["custom_data"] === "object" &&
-                  rowObj["custom_data"] !== null &&
-                  !Array.isArray(rowObj["custom_data"])
-                    ? (rowObj["custom_data"] as Record<string, unknown>)
-                    : {}),
-                };
+                const baseline = getVolunteerCustomDataMap(
+                  allVolunteers.find((v) => v.id === rowId) || ({} as Volunteer)
+                );
+                const cd = mergeCustomDataFromRow(rowId, rowObj, allVolunteers);
                 delete cd[ck];
-                if (Object.keys(cd).length === 0) delete rowObj["custom_data"];
-                else rowObj["custom_data"] = cd;
+                if (customDataEquals(cd, baseline)) {
+                  delete rowObj["custom_data"];
+                } else {
+                  rowObj["custom_data"] = cd;
+                }
               } else {
                 delete rowObj[colId];
               }
@@ -264,14 +282,11 @@ export const useVolunteerEdits = ({
             }
           } else if (ck) {
             const prevRow = next[rowId] as Record<string, unknown> | undefined;
-            const prevCd =
-              prevRow &&
-              typeof prevRow["custom_data"] === "object" &&
-              prevRow["custom_data"] !== null &&
-              !Array.isArray(prevRow["custom_data"])
-                ? { ...(prevRow["custom_data"] as Record<string, unknown>) }
-                : {};
-            const merged = { ...prevCd };
+            const merged = mergeCustomDataFromRow(
+              rowId,
+              prevRow || {},
+              allVolunteers
+            );
             if (finalValue === null || finalValue === undefined) {
               delete merged[ck];
             } else {
@@ -338,7 +353,7 @@ export const useVolunteerEdits = ({
         });
       });
     },
-    [setData, setEditedRows, cellMatchesOriginal]
+    [setData, setEditedRows, cellMatchesOriginal, allVolunteers]
   );
 
   const handleCellEdit = useCallback(

--- a/src/components/volunteers/useVolunteerEdits.ts
+++ b/src/components/volunteers/useVolunteerEdits.ts
@@ -7,6 +7,11 @@ import { updateVolunteer } from "@/lib/api/updateVolunteer";
 import { createRole } from "@/lib/api/createRole";
 import { createCohort } from "@/lib/api/createCohort";
 import { sortCohorts, sortRoles } from "./utils";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
+import {
+  parseCustomColumnTableId,
+  getVolunteerCustomDataMap,
+} from "./volunteerColumns";
 
 interface UseVolunteerEditsProps {
   editedRows: Record<number, Partial<Volunteer>>;
@@ -16,6 +21,7 @@ interface UseVolunteerEditsProps {
   allVolunteers: Volunteer[];
   allRoles: RoleRow[];
   allCohorts: CohortRow[];
+  customColumns: CustomColumnRow[];
   setData: React.Dispatch<React.SetStateAction<Volunteer[]>>;
   setAllVolunteers: React.Dispatch<React.SetStateAction<Volunteer[]>>;
   bumpDisplayRefresh: () => void;
@@ -54,23 +60,36 @@ export interface UseVolunteerEditsReturn {
 
 const MAX_HISTORY = 100;
 
-function mergeSavedVolunteersIntoAll(
-  prev: Volunteer[],
-  editsSnapshot: Record<number, Partial<Volunteer>>,
-  remainingEdits: Record<number, Partial<Volunteer>>
-): Volunteer[] {
-  const failedIds = new Set(
-    Object.keys(remainingEdits).map((k) => Number.parseInt(k, 10))
-  );
-  return prev.map((v) => {
-    if (failedIds.has(v.id) || !editsSnapshot[v.id]) {
-      return v;
+const normalizeValue = (
+  colId: string,
+  value: unknown,
+  customColumns: CustomColumnRow[]
+): unknown => {
+  const customKey = parseCustomColumnTableId(colId);
+  if (customKey) {
+    const def = customColumns.find((c) => c.column_key === customKey);
+    if (def?.data_type === "number") {
+      if (value === null || value === undefined || value === "") return null;
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+      if (typeof value === "string") {
+        const s = value.trim();
+        if (s === "") return null;
+        const n = Number(s);
+        return Number.isFinite(n) ? n : value;
+      }
+      return value;
     }
-    return { ...v, ...editsSnapshot[v.id] };
-  });
-}
+    if (def?.data_type === "boolean") {
+      if (value === "Yes") return true;
+      if (value === "No") return false;
+      return value;
+    }
+    if (def?.data_type === "tag" && def.is_multi && Array.isArray(value)) {
+      return [...(value as string[])].sort();
+    }
+    return value;
+  }
 
-const normalizeValue = (colId: string, value: unknown): unknown => {
   if (colId === "pronouns") {
     if (Array.isArray(value)) {
       if (value.length === 0) return null;
@@ -100,6 +119,7 @@ export const useVolunteerEdits = ({
   allVolunteers,
   allRoles,
   allCohorts,
+  customColumns,
   setData,
   setAllVolunteers,
   bumpDisplayRefresh,
@@ -134,6 +154,17 @@ export const useVolunteerEdits = ({
   const getCellValue = useCallback(
     (rowId: number, colId: string): unknown => {
       const edited = editedRowsRef.current[rowId];
+      const customKey = parseCustomColumnTableId(colId);
+      if (customKey) {
+        if (edited?.custom_data && typeof edited.custom_data === "object") {
+          const m = edited.custom_data as Record<string, unknown>;
+          if (Object.prototype.hasOwnProperty.call(m, customKey)) {
+            return m[customKey];
+          }
+        }
+        const row = allVolunteers.find((v) => v.id === rowId);
+        return row ? getVolunteerCustomDataMap(row)[customKey] : undefined;
+      }
       if (edited && colId in edited)
         return (edited as Record<string, unknown>)[colId];
       return allVolunteers.find((v) => v.id === rowId)?.[
@@ -146,6 +177,35 @@ export const useVolunteerEdits = ({
   const cellMatchesOriginal = useCallback(
     (rowId: number, colId: string, finalValue: unknown): boolean => {
       const originalRow = allVolunteers.find((v) => v.id === rowId);
+      const customKey = parseCustomColumnTableId(colId);
+      if (customKey && originalRow) {
+        const originalValue = getVolunteerCustomDataMap(originalRow)[customKey];
+        if (Array.isArray(finalValue) && Array.isArray(originalValue)) {
+          return (
+            JSON.stringify([...(finalValue as string[])].sort()) ===
+            JSON.stringify([...(originalValue as string[])].sort())
+          );
+        }
+        if (Array.isArray(finalValue) || Array.isArray(originalValue)) {
+          return false;
+        }
+        if (
+          typeof finalValue === "boolean" ||
+          typeof originalValue === "boolean"
+        ) {
+          return finalValue === originalValue;
+        }
+        if (
+          typeof finalValue === "number" ||
+          typeof originalValue === "number"
+        ) {
+          return finalValue === originalValue;
+        }
+        const norm = (v: unknown): string =>
+          v === null || v === undefined ? "" : String(v);
+        return norm(finalValue) === norm(originalValue);
+      }
+
       const originalValue = originalRow
         ? originalRow[colId as keyof Volunteer]
         : undefined;
@@ -178,16 +238,49 @@ export const useVolunteerEdits = ({
         const next: Record<number, Partial<Volunteer>> = { ...prev };
         for (const { rowId, colId, value: finalValue } of edits) {
           const matchesOriginal = cellMatchesOriginal(rowId, colId, finalValue);
+          const ck = parseCustomColumnTableId(colId);
           if (matchesOriginal) {
             if (next[rowId]) {
               const rowObj = { ...(next[rowId] as Record<string, unknown>) };
-              delete rowObj[colId];
+              if (ck) {
+                const cd = {
+                  ...(typeof rowObj["custom_data"] === "object" &&
+                  rowObj["custom_data"] !== null &&
+                  !Array.isArray(rowObj["custom_data"])
+                    ? (rowObj["custom_data"] as Record<string, unknown>)
+                    : {}),
+                };
+                delete cd[ck];
+                if (Object.keys(cd).length === 0) delete rowObj["custom_data"];
+                else rowObj["custom_data"] = cd;
+              } else {
+                delete rowObj[colId];
+              }
               if (Object.keys(rowObj).length === 0) {
                 delete next[rowId];
               } else {
                 next[rowId] = rowObj as Partial<Volunteer>;
               }
             }
+          } else if (ck) {
+            const prevRow = next[rowId] as Record<string, unknown> | undefined;
+            const prevCd =
+              prevRow &&
+              typeof prevRow["custom_data"] === "object" &&
+              prevRow["custom_data"] !== null &&
+              !Array.isArray(prevRow["custom_data"])
+                ? { ...(prevRow["custom_data"] as Record<string, unknown>) }
+                : {};
+            const merged = { ...prevCd };
+            if (finalValue === null || finalValue === undefined) {
+              delete merged[ck];
+            } else {
+              merged[ck] = finalValue;
+            }
+            next[rowId] = {
+              ...(prevRow || {}),
+              custom_data: merged,
+            } as Partial<Volunteer>;
           } else {
             next[rowId] = { ...(next[rowId] || {}), [colId]: finalValue };
           }
@@ -214,8 +307,30 @@ export const useVolunteerEdits = ({
       setData((prev) => {
         const byRow = new Map<number, Record<string, unknown>>();
         for (const { rowId, colId, value: finalValue } of edits) {
-          if (!byRow.has(rowId)) byRow.set(rowId, {});
-          byRow.get(rowId)![colId] = finalValue;
+          const ck = parseCustomColumnTableId(colId);
+          if (ck) {
+            if (!byRow.has(rowId)) byRow.set(rowId, {});
+            const rowPatch = byRow.get(rowId)!;
+            const baseCd = {
+              ...getVolunteerCustomDataMap(
+                prev.find((x) => x.id === rowId) as Volunteer
+              ),
+              ...(typeof rowPatch["custom_data"] === "object" &&
+              rowPatch["custom_data"] !== null &&
+              !Array.isArray(rowPatch["custom_data"])
+                ? (rowPatch["custom_data"] as Record<string, unknown>)
+                : {}),
+            };
+            if (finalValue === null || finalValue === undefined) {
+              delete baseCd[ck];
+            } else {
+              baseCd[ck] = finalValue;
+            }
+            rowPatch["custom_data"] = baseCd;
+          } else {
+            if (!byRow.has(rowId)) byRow.set(rowId, {});
+            byRow.get(rowId)![colId] = finalValue;
+          }
         }
         return prev.map((r) => {
           const patch = byRow.get(r.id);
@@ -228,7 +343,7 @@ export const useVolunteerEdits = ({
 
   const handleCellEdit = useCallback(
     (rowId: number, colId: string, value: unknown): void => {
-      const finalValue = normalizeValue(colId, value);
+      const finalValue = normalizeValue(colId, value, customColumns);
 
       if (!isUndoRedoRef.current) {
         const priorValue = getCellValue(rowId, colId);
@@ -242,7 +357,7 @@ export const useVolunteerEdits = ({
       applyEditsBatch([{ rowId, colId, value: finalValue }]);
       syncHistoryStacks();
     },
-    [getCellValue, applyEditsBatch, syncHistoryStacks]
+    [getCellValue, applyEditsBatch, syncHistoryStacks, customColumns]
   );
 
   const handleBulkEdit = useCallback(
@@ -265,13 +380,13 @@ export const useVolunteerEdits = ({
       const normalized = edits.map(({ rowId, colId, value }) => ({
         rowId,
         colId,
-        value: normalizeValue(colId, value),
+        value: normalizeValue(colId, value, customColumns),
       }));
       applyEditsBatch(normalized);
 
       syncHistoryStacks();
     },
-    [getCellValue, applyEditsBatch, syncHistoryStacks]
+    [getCellValue, applyEditsBatch, syncHistoryStacks, customColumns]
   );
 
   const undo = useCallback((): void => {

--- a/src/components/volunteers/useVolunteersData.ts
+++ b/src/components/volunteers/useVolunteersData.ts
@@ -121,6 +121,12 @@ export const useVolunteersData = ({
 
         return {
           ...entry.volunteer,
+          custom_data:
+            entry.volunteer.custom_data &&
+            typeof entry.volunteer.custom_data === "object" &&
+            !Array.isArray(entry.volunteer.custom_data)
+              ? entry.volunteer.custom_data
+              : {},
           cohorts: entry.cohorts.map(formatTag).sort(sortCohorts),
           current_roles: entry.roles
             .filter((r) => r.type === "current")

--- a/src/components/volunteers/useVolunteersData.ts
+++ b/src/components/volunteers/useVolunteersData.ts
@@ -48,6 +48,8 @@ function formatFilterTupleForApi(f: FilterTuple): FilterTuple {
 interface UseVolunteersDataProps {
   isAdmin: boolean;
   editedRowsRef: React.RefObject<Record<number, Partial<Volunteer>>>;
+  /** Used to re-merge table rows when edits change without re-fetching filters (ref alone does not trigger effects). */
+  editedRows: Record<number, Partial<Volunteer>>;
 }
 
 export interface UseVolunteersDataReturn {
@@ -80,6 +82,7 @@ export interface UseVolunteersDataReturn {
 export const useVolunteersData = ({
   isAdmin,
   editedRowsRef,
+  editedRows,
 }: UseVolunteersDataProps): UseVolunteersDataReturn => {
   const [data, setData] = useState<Volunteer[]>([]);
   const [allVolunteers, setAllVolunteers] = useState<Volunteer[]>([]);
@@ -95,6 +98,13 @@ export const useVolunteersData = ({
   const [globalOp, setGlobalOp] = useState<"AND" | "OR">("AND");
   const debouncedFilters = useDebounce(filters);
   const debouncedGlobalOp = useDebounce(globalOp);
+
+  /** Last successful column-filter id set (opt-in + column filters). Used to re-apply row overlays when `editedRows` changes. */
+  const lastFilteredIdsRef = useRef<Set<number> | null>(null);
+  const allVolunteersRef = useRef<Volunteer[]>(allVolunteers);
+  const debouncedFiltersRef = useRef<FilterTuple[]>(debouncedFilters);
+  allVolunteersRef.current = allVolunteers;
+  debouncedFiltersRef.current = debouncedFilters;
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -196,6 +206,7 @@ export const useVolunteersData = ({
       }
 
       if (debouncedFilters.length === 0) {
+        lastFilteredIdsRef.current = null;
         setData(
           allVolunteers.map((v) =>
             editedRowsRef.current && editedRowsRef.current[v.id]
@@ -261,6 +272,7 @@ export const useVolunteersData = ({
         if (!ignore) {
           if (filterResult.error) throw new Error(filterResult.error);
           const filteredIds = new Set(filterResult.data || []);
+          lastFilteredIdsRef.current = filteredIds;
 
           setData(
             allVolunteers
@@ -290,6 +302,26 @@ export const useVolunteersData = ({
     editedRowsRef,
     displayRefreshEpoch,
   ]);
+
+  /** Re-merge pending edits onto the last filtered row set when `editedRows` changes (refs do not re-run the filter effect). */
+  useEffect(() => {
+    const rows = allVolunteersRef.current;
+    if (!rows.length) return;
+
+    const merge = (v: Volunteer): Volunteer =>
+      editedRows[v.id] ? { ...v, ...editedRows[v.id] } : v;
+
+    const filters = debouncedFiltersRef.current;
+    if (filters.length === 0) {
+      setData(rows.map(merge));
+      return;
+    }
+
+    const ids = lastFilteredIdsRef.current;
+    if (!ids) return;
+
+    setData(rows.filter((v) => ids.has(v.id)).map(merge));
+  }, [editedRows]);
 
   return {
     data,

--- a/src/components/volunteers/utils.ts
+++ b/src/components/volunteers/utils.ts
@@ -24,38 +24,39 @@ export const sortRoles = (a: string, b: string): number => a.localeCompare(b);
 export const formatCellData = (value: unknown): string => {
   if (Array.isArray(value)) return value.join(", ");
   if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
   return String(value);
 };
 
-const TAG_COLORS = [
-  "bg-tag-blue",
-  "bg-tag-green",
-  "bg-tag-yellow",
-  "bg-tag-pink",
-  "bg-tag-purple",
-  "bg-tag-orange",
-  "bg-tag-brown",
-  "bg-tag-red",
-  "bg-tag-gray",
+/** Theme tokens from `src/styles/variables.css` @theme — use inline so colors always apply (avoids purged Tailwind classes). */
+const TAG_BG_VARS = [
+  "var(--color-tag-blue)",
+  "var(--color-tag-green)",
+  "var(--color-tag-yellow)",
+  "var(--color-tag-pink)",
+  "var(--color-tag-purple)",
+  "var(--color-tag-orange)",
+  "var(--color-tag-brown)",
+  "var(--color-tag-red)",
 ] as const;
 
-const EXPLICIT_TAG_COLORS: Record<string, string> = {
-  yes: "bg-tag-green",
-  no: "bg-tag-red",
-  "she/her": "bg-tag-pink",
-  "he/him": "bg-tag-purple",
-  "they/them": "bg-tag-yellow",
-  "emergency back-up": "bg-tag-red",
+const EXPLICIT_TAG_BG: Record<string, string> = {
+  yes: "var(--color-tag-green)",
+  no: "var(--color-tag-red)",
+  "she/her": "var(--color-tag-pink)",
+  "he/him": "var(--color-tag-purple)",
+  "they/them": "var(--color-tag-yellow)",
+  "emergency back-up": "var(--color-tag-red)",
 };
 
-const KEYWORD_TAG_COLORS: [string, string][] = [
-  ["fall", "bg-tag-yellow"],
-  ["summer", "bg-tag-green"],
-  ["spring", "bg-tag-blue"],
-  ["winter", "bg-tag-pink"],
+const KEYWORD_TAG_BG: [string, string][] = [
+  ["fall", "var(--color-tag-yellow)"],
+  ["summer", "var(--color-tag-green)"],
+  ["spring", "var(--color-tag-blue)"],
+  ["winter", "var(--color-tag-pink)"],
 ];
 
-const assignedColors = new Map<string, string>();
+const assignedTagBackground = new Map<string, string>();
 
 function stableColorIndexForLabel(text: string): number {
   let h = 0;
@@ -65,21 +66,22 @@ function stableColorIndexForLabel(text: string): number {
   return Math.abs(h);
 }
 
-export const getTagColorClass = (label: string): string => {
+/** Returns a CSS `background-color` value (theme variable) for tag labels. */
+export function getTagBackgroundColor(label: string): string {
   const text = label.toLowerCase();
 
-  const explicit = EXPLICIT_TAG_COLORS[text];
+  const explicit = EXPLICIT_TAG_BG[text];
   if (explicit) return explicit;
 
-  for (const [keyword, color] of KEYWORD_TAG_COLORS) {
-    if (text.includes(keyword)) return color;
+  for (const [keyword, bg] of KEYWORD_TAG_BG) {
+    if (text.includes(keyword)) return bg;
   }
 
-  const cached = assignedColors.get(text);
+  const cached = assignedTagBackground.get(text);
   if (cached) return cached;
 
-  const idx = stableColorIndexForLabel(text) % TAG_COLORS.length;
-  const color = TAG_COLORS[idx] ?? "bg-tag-gray";
-  assignedColors.set(text, color);
-  return color;
-};
+  const idx = stableColorIndexForLabel(text) % TAG_BG_VARS.length;
+  const bg = TAG_BG_VARS[idx] ?? "var(--color-tag-gray)";
+  assignedTagBackground.set(text, bg);
+  return bg;
+}

--- a/src/components/volunteers/volunteerColumns.tsx
+++ b/src/components/volunteers/volunteerColumns.tsx
@@ -179,7 +179,7 @@ export const NEW_VOLUNTEER_FORM_COLUMNS = COLUMNS_CONFIG.filter(
 export type FilterableColumnDesc = {
   id: string;
   label: string;
-  type: "text" | "options";
+  type: "text" | "options" | "number";
   icon: React.ElementType;
   isMulti: boolean;
 };
@@ -235,11 +235,20 @@ export function buildFilterableColumnList(
   const builtIn = FILTERABLE_COLUMNS;
   const custom: FilterableColumnDesc[] = customColumns.map((c) => {
     const id = tableIdForCustomColumn(c.column_key);
-    if (c.data_type === "text" || c.data_type === "number") {
+    if (c.data_type === "text") {
       return {
         id,
         label: c.name,
         type: "text",
+        icon: customColumnIcon(c.data_type),
+        isMulti: false,
+      };
+    }
+    if (c.data_type === "number") {
+      return {
+        id,
+        label: c.name,
+        type: "number",
         icon: customColumnIcon(c.data_type),
         isMulti: false,
       };

--- a/src/components/volunteers/volunteerColumns.tsx
+++ b/src/components/volunteers/volunteerColumns.tsx
@@ -17,6 +17,7 @@ import {
   ToggleLeft,
 } from "lucide-react";
 import type { CustomColumnRow } from "@/lib/api/customColumns";
+import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
 
 type FilterType = "text" | "options" | null;
 
@@ -339,10 +340,7 @@ export function buildDynamicColumns(
   optionsData: Record<string, string[]> = {}
 ): ColumnDef<Volunteer>[] {
   const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
-  const hidden = new Set(userPrefs.hidden_columns);
-  const fundamental = new Set<string>(
-    FUNDAMENTAL_COLUMN_IDS.map((x) => String(x))
-  );
+  const hidden = new Set(sanitizeHiddenColumnIds(userPrefs.hidden_columns));
 
   let ordered = orderedColumnIds(
     builtInIds,
@@ -351,11 +349,13 @@ export function buildDynamicColumns(
     userPrefs.prefs_updated_at ?? null
   );
 
-  ordered = ordered.filter((id) => fundamental.has(id) || !hidden.has(id));
+  ordered = ordered.filter((id) => !hidden.has(id));
 
   const idColumnFirst = "volunteer_id";
   ordered = ordered.filter((id) => id !== idColumnFirst);
-  ordered = [idColumnFirst, ...ordered];
+  if (!hidden.has(idColumnFirst)) {
+    ordered = [idColumnFirst, ...ordered];
+  }
 
   const builtInById = new Map(
     COLUMNS_CONFIG.map((c) => [String(c.id), c] as const)

--- a/src/components/volunteers/volunteerColumns.tsx
+++ b/src/components/volunteers/volunteerColumns.tsx
@@ -14,7 +14,9 @@ import {
   List,
   TextAlignStart,
   Bell,
+  ToggleLeft,
 } from "lucide-react";
+import type { CustomColumnRow } from "@/lib/api/customColumns";
 
 type FilterType = "text" | "options" | null;
 
@@ -173,16 +175,269 @@ export const NEW_VOLUNTEER_FORM_COLUMNS = COLUMNS_CONFIG.filter(
   (col) => col.id !== ("volunteer_id" as keyof Volunteer)
 );
 
-export const FILTERABLE_COLUMNS = COLUMNS_CONFIG.filter(
+export type FilterableColumnDesc = {
+  id: string;
+  label: string;
+  type: "text" | "options";
+  icon: React.ElementType;
+  isMulti: boolean;
+};
+
+export const FILTERABLE_COLUMNS: FilterableColumnDesc[] = COLUMNS_CONFIG.filter(
   (col) => col.filterType !== null
 ).map((col) => ({
-  id: col.id,
+  id: String(col.id),
   label: col.label,
   type: col.filterType as "text" | "options",
   icon: col.icon,
   isMulti: col.isMulti ?? false,
 }));
 
+export const FUNDAMENTAL_COLUMN_IDS = [
+  "volunteer_id",
+  "name_org",
+  "email",
+  "phone",
+] as const;
+
+export const CUSTOM_COLUMN_ID_PREFIX = "custom__";
+
+export function tableIdForCustomColumn(columnKey: string): string {
+  return `${CUSTOM_COLUMN_ID_PREFIX}${columnKey}`;
+}
+
+export function parseCustomColumnTableId(columnId: string): string | null {
+  if (!columnId.startsWith(CUSTOM_COLUMN_ID_PREFIX)) return null;
+  return columnId.slice(CUSTOM_COLUMN_ID_PREFIX.length);
+}
+
+export function getVolunteerCustomDataMap(
+  v: Volunteer
+): Record<string, unknown> {
+  const cd = v.custom_data;
+  if (cd && typeof cd === "object" && !Array.isArray(cd)) {
+    return cd as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function customColumnIcon(dataType: string): React.ElementType {
+  if (dataType === "number") return Hash;
+  if (dataType === "boolean") return ToggleLeft;
+  if (dataType === "tag") return List;
+  return CaseSensitive;
+}
+
+export function buildFilterableColumnList(
+  customColumns: CustomColumnRow[]
+): FilterableColumnDesc[] {
+  const builtIn = FILTERABLE_COLUMNS;
+  const custom: FilterableColumnDesc[] = customColumns.map((c) => {
+    const id = tableIdForCustomColumn(c.column_key);
+    if (c.data_type === "text" || c.data_type === "number") {
+      return {
+        id,
+        label: c.name,
+        type: "text",
+        icon: customColumnIcon(c.data_type),
+        isMulti: false,
+      };
+    }
+    return {
+      id,
+      label: c.name,
+      type: "options",
+      icon: customColumnIcon(c.data_type),
+      isMulti: c.data_type === "tag" ? Boolean(c.is_multi) : false,
+    };
+  });
+  return [...builtIn, ...custom];
+}
+
+export function orderedColumnIds(
+  builtInIds: string[],
+  customColumns: CustomColumnRow[],
+  savedOrder: string[]
+): string[] {
+  const customSorted = [...customColumns].sort(
+    (a, b) => a.default_position - b.default_position || a.id - b.id
+  );
+  const customIds = customSorted.map((c) =>
+    tableIdForCustomColumn(c.column_key)
+  );
+  const allKnown = [...builtInIds, ...customIds];
+
+  if (savedOrder.length === 0) {
+    return allKnown;
+  }
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of savedOrder) {
+    if (!allKnown.includes(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  for (const id of allKnown) {
+    if (!seen.has(id)) out.push(id);
+  }
+  return out;
+}
+
+const renderCustomBooleanTag = (
+  info: CellContext<Volunteer, unknown>
+): React.JSX.Element => {
+  const value = info.getValue();
+  if (value === true) return <VolunteerTag label="Yes" />;
+  if (value === false) return <VolunteerTag label="No" />;
+  return <></>;
+};
+
+const renderCustomNumber = (
+  info: CellContext<Volunteer, unknown>
+): React.JSX.Element => {
+  const value = info.getValue();
+  if (value === null || value === undefined || value === "") return <></>;
+  return (
+    <span className="tabular-nums text-right block w-full">
+      {String(value)}
+    </span>
+  );
+};
+
+export function buildDynamicColumns(
+  customColumns: CustomColumnRow[],
+  userPrefs: { column_order: string[]; hidden_columns: string[] },
+  isAdmin: boolean,
+  onEdit?: (rowId: number, colId: string, value: unknown) => void,
+  optionsData: Record<string, string[]> = {}
+): ColumnDef<Volunteer>[] {
+  const builtInIds = COLUMNS_CONFIG.map((c) => String(c.id));
+  const hidden = new Set(userPrefs.hidden_columns);
+  const fundamental = new Set<string>(
+    FUNDAMENTAL_COLUMN_IDS.map((x) => String(x))
+  );
+
+  let ordered = orderedColumnIds(
+    builtInIds,
+    customColumns,
+    userPrefs.column_order
+  );
+
+  ordered = ordered.filter((id) => fundamental.has(id) || !hidden.has(id));
+
+  const idColumnFirst = "volunteer_id";
+  ordered = ordered.filter((id) => id !== idColumnFirst);
+  ordered = [idColumnFirst, ...ordered];
+
+  const builtInById = new Map(
+    COLUMNS_CONFIG.map((c) => [String(c.id), c] as const)
+  );
+  const customByKey = new Map(
+    customColumns.map((c) => [c.column_key, c] as const)
+  );
+
+  const defs: ColumnDef<Volunteer>[] = ordered.map((colId) => {
+    const builtIn = builtInById.get(colId);
+    if (builtIn) {
+      const col = builtIn;
+      const isEditable =
+        isAdmin &&
+        onEdit !== undefined &&
+        col.id !== ("volunteer_id" as keyof Volunteer);
+
+      return {
+        id: col.id as string,
+        header: () => <HeaderWithIcon icon={col.icon} label={col.label} />,
+        size: col.size,
+        sortDescFirst: false,
+        ...(col.accessorFn
+          ? { accessorFn: col.accessorFn }
+          : { accessorKey: col.id }),
+
+        ...(isEditable && onEdit
+          ? {
+              cell: (info: CellContext<Volunteer, unknown>) => (
+                <EditableCell
+                  info={info}
+                  onEdit={onEdit}
+                  type={col.filterType === "options" ? "options" : "text"}
+                  isMulti={col.isMulti ?? false}
+                  options={optionsData[col.id as string] || []}
+                />
+              ),
+            }
+          : col.cell
+            ? { cell: col.cell }
+            : {}),
+      } as ColumnDef<Volunteer>;
+    }
+
+    const customKey = parseCustomColumnTableId(colId);
+    const cc = customKey ? customByKey.get(customKey) : undefined;
+    if (!cc) {
+      return {
+        id: colId,
+        header: colId,
+        size: 120,
+      } as ColumnDef<Volunteer>;
+    }
+
+    const icon = customColumnIcon(cc.data_type);
+    const accessorFn = (row: Volunteer): unknown =>
+      getVolunteerCustomDataMap(row)[cc.column_key] ?? null;
+
+    const isEditable = isAdmin && onEdit !== undefined;
+
+    let readCell:
+      | ((info: CellContext<Volunteer, unknown>) => React.JSX.Element)
+      | undefined;
+
+    if (cc.data_type === "number") {
+      readCell = renderCustomNumber;
+    } else if (cc.data_type === "boolean") {
+      readCell = renderCustomBooleanTag;
+    } else if (cc.data_type === "tag") {
+      readCell = cc.is_multi ? renderMultiTags : renderSingleTag;
+    }
+
+    const editableType =
+      cc.data_type === "tag"
+        ? "options"
+        : cc.data_type === "number"
+          ? "number"
+          : cc.data_type === "boolean"
+            ? "boolean"
+            : "text";
+
+    return {
+      id: colId,
+      header: () => <HeaderWithIcon icon={icon} label={cc.name} />,
+      size: 140,
+      sortDescFirst: false,
+      accessorFn,
+      ...(isEditable && onEdit
+        ? {
+            cell: (info: CellContext<Volunteer, unknown>) => (
+              <EditableCell
+                info={info}
+                onEdit={onEdit}
+                type={editableType}
+                isMulti={Boolean(cc.is_multi)}
+                options={optionsData[colId] || cc.tag_options || []}
+              />
+            ),
+          }
+        : readCell
+          ? { cell: readCell }
+          : {}),
+    } as ColumnDef<Volunteer>;
+  });
+
+  return defs;
+}
+
+/** @deprecated Use buildDynamicColumns with custom columns + preferences */
 export const getBaseColumns = (
   isAdmin: boolean = false,
   onEdit?: (rowId: number, colId: string, value: unknown) => void,

--- a/src/components/volunteers/volunteerColumns.tsx
+++ b/src/components/volunteers/volunteerColumns.tsx
@@ -18,6 +18,19 @@ import {
 } from "lucide-react";
 import type { CustomColumnRow } from "@/lib/api/customColumns";
 import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
+import {
+  CUSTOM_COLUMN_ID_PREFIX,
+  tableIdForCustomColumn,
+  parseCustomColumnTableId,
+  orderedColumnIds,
+} from "@/lib/volunteerTable/columnOrder";
+
+export {
+  CUSTOM_COLUMN_ID_PREFIX,
+  tableIdForCustomColumn,
+  parseCustomColumnTableId,
+  orderedColumnIds,
+};
 
 type FilterType = "text" | "options" | null;
 
@@ -201,17 +214,6 @@ export const FUNDAMENTAL_COLUMN_IDS = [
   "phone",
 ] as const;
 
-export const CUSTOM_COLUMN_ID_PREFIX = "custom__";
-
-export function tableIdForCustomColumn(columnKey: string): string {
-  return `${CUSTOM_COLUMN_ID_PREFIX}${columnKey}`;
-}
-
-export function parseCustomColumnTableId(columnId: string): string | null {
-  if (!columnId.startsWith(CUSTOM_COLUMN_ID_PREFIX)) return null;
-  return columnId.slice(CUSTOM_COLUMN_ID_PREFIX.length);
-}
-
 export function getVolunteerCustomDataMap(
   v: Volunteer
 ): Record<string, unknown> {
@@ -220,6 +222,50 @@ export function getVolunteerCustomDataMap(
     return cd as Record<string, unknown>;
   }
   return {};
+}
+
+/** Same rules as undo/save: compares one custom_data value to the server baseline. */
+export function editedCustomValueMatchesOriginal(
+  originalVal: unknown,
+  editedVal: unknown
+): boolean {
+  if (Array.isArray(editedVal) && Array.isArray(originalVal)) {
+    return (
+      JSON.stringify([...(editedVal as string[])].sort()) ===
+      JSON.stringify([...(originalVal as string[])].sort())
+    );
+  }
+  if (Array.isArray(editedVal) || Array.isArray(originalVal)) {
+    return false;
+  }
+  if (typeof editedVal === "boolean" || typeof originalVal === "boolean") {
+    return editedVal === originalVal;
+  }
+  if (typeof editedVal === "number" || typeof originalVal === "number") {
+    return editedVal === originalVal;
+  }
+  const norm = (v: unknown): string =>
+    v === null || v === undefined ? "" : String(v);
+  return norm(editedVal) === norm(originalVal);
+}
+
+/** True if this custom column key is part of the edit overlay and differs from the row baseline. */
+export function isCustomColumnCellModified(
+  originalRow: Volunteer,
+  customKey: string,
+  edit: Partial<Volunteer> | undefined
+): boolean {
+  if (
+    !edit?.custom_data ||
+    typeof edit.custom_data !== "object" ||
+    Array.isArray(edit.custom_data)
+  ) {
+    return false;
+  }
+  const m = edit.custom_data as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(m, customKey)) return false;
+  const origVal = getVolunteerCustomDataMap(originalRow)[customKey];
+  return !editedCustomValueMatchesOriginal(origVal, m[customKey]);
 }
 
 export function customColumnIcon(dataType: string): React.ElementType {
@@ -262,58 +308,6 @@ export function buildFilterableColumnList(
     };
   });
   return [...builtIn, ...custom];
-}
-
-export function orderedColumnIds(
-  builtInIds: string[],
-  customColumns: CustomColumnRow[],
-  savedOrder: string[],
-  /** When set, custom columns with created_at at or before this time are not auto-appended if missing from savedOrder (e.g. removed from prefs but not yet deleted in DB). */
-  prefsUpdatedAt?: string | null
-): string[] {
-  const customSorted = [...customColumns].sort(
-    (a, b) => a.default_position - b.default_position || a.id - b.id
-  );
-  const customIds = customSorted.map((c) =>
-    tableIdForCustomColumn(c.column_key)
-  );
-  const allKnown = [...builtInIds, ...customIds];
-
-  if (savedOrder.length === 0) {
-    return allKnown;
-  }
-
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const id of savedOrder) {
-    if (!allKnown.includes(id) || seen.has(id)) continue;
-    seen.add(id);
-    out.push(id);
-  }
-  for (const id of builtInIds) {
-    if (!seen.has(id)) {
-      seen.add(id);
-      out.push(id);
-    }
-  }
-  const prefsTime = prefsUpdatedAt ? Date.parse(prefsUpdatedAt) : NaN;
-  for (const c of customSorted) {
-    const id = tableIdForCustomColumn(c.column_key);
-    if (seen.has(id)) continue;
-    const created =
-      c.created_at != null && c.created_at !== ""
-        ? Date.parse(c.created_at)
-        : NaN;
-    const appendNewCustom =
-      !Number.isFinite(prefsTime) ||
-      !Number.isFinite(created) ||
-      created > prefsTime;
-    if (appendNewCustom) {
-      seen.add(id);
-      out.push(id);
-    }
-  }
-  return out;
 }
 
 const renderCustomBooleanTag = (

--- a/src/components/volunteers/volunteerColumns.tsx
+++ b/src/components/volunteers/volunteerColumns.tsx
@@ -257,7 +257,9 @@ export function buildFilterableColumnList(
 export function orderedColumnIds(
   builtInIds: string[],
   customColumns: CustomColumnRow[],
-  savedOrder: string[]
+  savedOrder: string[],
+  /** When set, custom columns with created_at at or before this time are not auto-appended if missing from savedOrder (e.g. removed from prefs but not yet deleted in DB). */
+  prefsUpdatedAt?: string | null
 ): string[] {
   const customSorted = [...customColumns].sort(
     (a, b) => a.default_position - b.default_position || a.id - b.id
@@ -278,8 +280,28 @@ export function orderedColumnIds(
     seen.add(id);
     out.push(id);
   }
-  for (const id of allKnown) {
-    if (!seen.has(id)) out.push(id);
+  for (const id of builtInIds) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  const prefsTime = prefsUpdatedAt ? Date.parse(prefsUpdatedAt) : NaN;
+  for (const c of customSorted) {
+    const id = tableIdForCustomColumn(c.column_key);
+    if (seen.has(id)) continue;
+    const created =
+      c.created_at != null && c.created_at !== ""
+        ? Date.parse(c.created_at)
+        : NaN;
+    const appendNewCustom =
+      !Number.isFinite(prefsTime) ||
+      !Number.isFinite(created) ||
+      created > prefsTime;
+    if (appendNewCustom) {
+      seen.add(id);
+      out.push(id);
+    }
   }
   return out;
 }
@@ -307,7 +329,11 @@ const renderCustomNumber = (
 
 export function buildDynamicColumns(
   customColumns: CustomColumnRow[],
-  userPrefs: { column_order: string[]; hidden_columns: string[] },
+  userPrefs: {
+    column_order: string[];
+    hidden_columns: string[];
+    prefs_updated_at?: string | null;
+  },
   isAdmin: boolean,
   onEdit?: (rowId: number, colId: string, value: unknown) => void,
   optionsData: Record<string, string[]> = {}
@@ -321,7 +347,8 @@ export function buildDynamicColumns(
   let ordered = orderedColumnIds(
     builtInIds,
     customColumns,
-    userPrefs.column_order
+    userPrefs.column_order,
+    userPrefs.prefs_updated_at ?? null
   );
 
   ordered = ordered.filter((id) => fundamental.has(id) || !hidden.has(id));
@@ -425,6 +452,7 @@ export function buildDynamicColumns(
                 type={editableType}
                 isMulti={Boolean(cc.is_multi)}
                 options={optionsData[colId] || cc.tag_options || []}
+                allowAddTags={cc.data_type === "tag"}
               />
             ),
           }

--- a/src/components/volunteers/volunteersHelpContent.tsx
+++ b/src/components/volunteers/volunteersHelpContent.tsx
@@ -118,16 +118,26 @@ export function VolunteersHelpContent({
             <h3 className="font-semibold text-gray-900 mb-1.5">Admin tools</h3>
             <ul className="list-disc pl-5 space-y-1">
               <li>
+                Use <strong>Columns</strong> to reorder or show/hide columns,
+                and to add or remove <strong>custom columns</strong> (text,
+                number, Yes/No, or tags). Tag columns with a preset list are
+                pick-only; with no list, you can type new tags in the cell like
+                roles or cohorts—then <strong>Save Changes</strong>.
+              </li>
+              <li>
                 <strong>New Volunteer</strong> and{" "}
-                <strong>Import from CSV</strong> add rows to the table.
+                <strong>Import from CSV</strong> add rows to the table (CSV can
+                include optional{" "}
+                <code className="text-xs">custom:column_key</code> headers for
+                custom fields when those columns exist).
               </li>
               <li>
                 Select rows with the checkboxes, then <strong>Delete</strong> to
                 remove volunteers (you’ll confirm in a dialog).
               </li>
               <li>
-                New tags (roles, cohorts) can be typed in the cell editor; save
-                to persist them.
+                New tags for roles, cohorts, and freeform custom tag columns can
+                be typed in the cell editor; save to persist them.
               </li>
             </ul>
           </section>

--- a/src/lib/api/actions.ts
+++ b/src/lib/api/actions.ts
@@ -408,6 +408,7 @@ export async function updateCustomColumnAction(
 export async function getColumnPreferencesAction(): Promise<{
   column_order: string[];
   hidden_columns: string[];
+  prefs_updated_at: string | null;
 }> {
   const userId = await requireAuthenticatedUserId();
   return getColumnPreferencesForUser(userId);

--- a/src/lib/api/actions.ts
+++ b/src/lib/api/actions.ts
@@ -25,6 +25,20 @@ import { updateRole } from "./updateRole";
 import { updateCohort } from "./updateCohort";
 import { removeRoleById } from "./removeRole";
 import { removeCohort } from "./removeCohort";
+import {
+  createCustomColumnsBatch,
+  deleteCustomColumnsBatch,
+  listCustomColumns,
+  updateCustomColumn,
+  type ColumnMutationResult,
+  type CustomColumnRow,
+  type CustomColumnUpdate,
+  type NewCustomColumnInput,
+} from "./customColumns";
+import {
+  getColumnPreferencesForUser,
+  saveColumnPreferencesForUser,
+} from "./columnPreferences";
 
 type ImportCSVResponse = Awaited<ReturnType<typeof import_csv>>;
 
@@ -33,6 +47,14 @@ async function requireAdmin(): Promise<void> {
   if (!user || user.role !== "admin") {
     throw new Error("Unauthorized: admin access required");
   }
+}
+
+async function requireAuthenticatedUserId(): Promise<string> {
+  const user = await getCurrentUserServer();
+  if (!user) {
+    throw new Error("Unauthorized: sign in required");
+  }
+  return user.id;
 }
 
 export async function importCsvAction(
@@ -341,4 +363,68 @@ export async function removeAllCohortTagsAction(): Promise<
   }
   revalidateVolunteerTags();
   return { success: true, removed: ids.length };
+}
+
+export async function getCustomColumnsAction(): Promise<CustomColumnRow[]> {
+  await requireAuthenticatedUserId();
+  return listCustomColumns();
+}
+
+export async function createCustomColumnsAction(
+  columns: NewCustomColumnInput[]
+): Promise<ColumnMutationResult[]> {
+  await requireAdmin();
+  const u = await getCurrentUserServer();
+  const results = await createCustomColumnsBatch(columns, u?.id ?? null);
+  if (results.some((r) => r.success)) {
+    revalidatePath("/volunteers");
+  }
+  return results;
+}
+
+export async function deleteCustomColumnsAction(
+  columnIds: number[]
+): Promise<ColumnMutationResult[]> {
+  await requireAdmin();
+  const results = await deleteCustomColumnsBatch(columnIds);
+  if (results.some((r) => r.success)) {
+    revalidatePath("/volunteers");
+  }
+  return results;
+}
+
+export async function updateCustomColumnAction(
+  columnId: number,
+  patch: CustomColumnUpdate
+): Promise<{ success: boolean; error?: string }> {
+  await requireAdmin();
+  const res = await updateCustomColumn(columnId, patch);
+  if (res.success) {
+    revalidatePath("/volunteers");
+  }
+  return res;
+}
+
+export async function getColumnPreferencesAction(): Promise<{
+  column_order: string[];
+  hidden_columns: string[];
+}> {
+  const userId = await requireAuthenticatedUserId();
+  return getColumnPreferencesForUser(userId);
+}
+
+export async function saveColumnPreferencesAction(
+  column_order: string[],
+  hidden_columns: string[]
+): Promise<{ success: boolean; error?: string }> {
+  const userId = await requireAuthenticatedUserId();
+  const res = await saveColumnPreferencesForUser(
+    userId,
+    column_order,
+    hidden_columns
+  );
+  if (res.success) {
+    revalidatePath("/volunteers");
+  }
+  return res;
 }

--- a/src/lib/api/actions.ts
+++ b/src/lib/api/actions.ts
@@ -39,6 +39,10 @@ import {
   getColumnPreferencesForUser,
   saveColumnPreferencesForUser,
 } from "./columnPreferences";
+import {
+  getVolunteerTableGlobalSettings,
+  saveVolunteerTableGlobalSettings,
+} from "./volunteerTableGlobalSettings";
 
 type ImportCSVResponse = Awaited<ReturnType<typeof import_csv>>;
 
@@ -426,6 +430,25 @@ export async function saveColumnPreferencesAction(
   );
   if (res.success) {
     revalidatePath("/volunteers");
+  }
+  return res;
+}
+
+export async function getVolunteerTableGlobalSettingsAction(): Promise<{
+  admin_hidden_columns: string[];
+}> {
+  await requireAuthenticatedUserId();
+  return getVolunteerTableGlobalSettings();
+}
+
+export async function saveVolunteerTableGlobalSettingsAction(
+  admin_hidden_columns: string[]
+): Promise<{ success: boolean; error?: string }> {
+  await requireAdmin();
+  const res = await saveVolunteerTableGlobalSettings(admin_hidden_columns);
+  if (res.success) {
+    revalidatePath("/volunteers");
+    revalidatePath("/settings/table");
   }
   return res;
 }

--- a/src/lib/api/actions.ts
+++ b/src/lib/api/actions.ts
@@ -38,7 +38,9 @@ import {
 import {
   getColumnPreferencesForUser,
   saveColumnPreferencesForUser,
+  resolveStaffColumnPreferences,
 } from "./columnPreferences";
+import { tableIdForCustomColumn } from "@/lib/volunteerTable/columnOrder";
 import {
   getVolunteerTableGlobalSettings,
   saveVolunteerTableGlobalSettings,
@@ -371,7 +373,14 @@ export async function removeAllCohortTagsAction(): Promise<
 
 export async function getCustomColumnsAction(): Promise<CustomColumnRow[]> {
   await requireAuthenticatedUserId();
-  return listCustomColumns();
+  const cols = await listCustomColumns();
+  const user = await getCurrentUserServer();
+  if (user?.role === "admin") return cols;
+  const global = await getVolunteerTableGlobalSettings();
+  const hiddenSet = new Set(global.admin_hidden_columns);
+  return cols.filter(
+    (c) => !hiddenSet.has(tableIdForCustomColumn(c.column_key))
+  );
 }
 
 export async function createCustomColumnsAction(
@@ -393,6 +402,7 @@ export async function deleteCustomColumnsAction(
   const results = await deleteCustomColumnsBatch(columnIds);
   if (results.some((r) => r.success)) {
     revalidatePath("/volunteers");
+    revalidatePath("/settings/table");
   }
   return results;
 }
@@ -413,9 +423,16 @@ export async function getColumnPreferencesAction(): Promise<{
   column_order: string[];
   hidden_columns: string[];
   prefs_updated_at: string | null;
+  /** Staff only: merged hidden for rendering; admins merge client-side with global settings. */
+  hidden_columns_effective?: string[];
 }> {
   const userId = await requireAuthenticatedUserId();
-  return getColumnPreferencesForUser(userId);
+  const user = await getCurrentUserServer();
+  const prefs = await getColumnPreferencesForUser(userId);
+  if (user?.role === "admin") {
+    return prefs;
+  }
+  return resolveStaffColumnPreferences(prefs);
 }
 
 export async function saveColumnPreferencesAction(
@@ -423,11 +440,16 @@ export async function saveColumnPreferencesAction(
   hidden_columns: string[]
 ): Promise<{ success: boolean; error?: string }> {
   const userId = await requireAuthenticatedUserId();
-  const res = await saveColumnPreferencesForUser(
-    userId,
-    column_order,
-    hidden_columns
-  );
+  const user = await getCurrentUserServer();
+  let co = column_order;
+  let hc = hidden_columns;
+  if (user?.role !== "admin") {
+    const global = await getVolunteerTableGlobalSettings();
+    const globalSet = new Set(global.admin_hidden_columns);
+    hc = hidden_columns.filter((id) => !globalSet.has(id));
+    co = column_order.filter((id) => !globalSet.has(id));
+  }
+  const res = await saveColumnPreferencesForUser(userId, co, hc);
   if (res.success) {
     revalidatePath("/volunteers");
   }
@@ -438,6 +460,10 @@ export async function getVolunteerTableGlobalSettingsAction(): Promise<{
   admin_hidden_columns: string[];
 }> {
   await requireAuthenticatedUserId();
+  const user = await getCurrentUserServer();
+  if (user?.role !== "admin") {
+    return { admin_hidden_columns: [] };
+  }
   return getVolunteerTableGlobalSettings();
 }
 

--- a/src/lib/api/columnPreferences.ts
+++ b/src/lib/api/columnPreferences.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { createAdminClient } from "@/lib/client/supabase/server";
+import type { Json } from "@/lib/client/supabase/types";
+
+function parseStringArray(
+  json: Json | null | undefined,
+  fallback: string[]
+): string[] {
+  if (!Array.isArray(json)) return fallback;
+  return json.filter((x): x is string => typeof x === "string");
+}
+
+export type ColumnPreferences = {
+  column_order: string[];
+  hidden_columns: string[];
+};
+
+export async function getColumnPreferencesForUser(
+  userId: string
+): Promise<ColumnPreferences> {
+  const client = createAdminClient();
+  const { data, error } = await client
+    .from("UserColumnPreferences")
+    .select("column_order, hidden_columns")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) {
+    return { column_order: [], hidden_columns: [] };
+  }
+
+  return {
+    column_order: parseStringArray(data.column_order, []),
+    hidden_columns: parseStringArray(data.hidden_columns, []),
+  };
+}
+
+export async function saveColumnPreferencesForUser(
+  userId: string,
+  column_order: string[],
+  hidden_columns: string[]
+): Promise<{ success: boolean; error?: string }> {
+  const client = createAdminClient();
+  const now = new Date().toISOString();
+
+  const { error } = await client.from("UserColumnPreferences").upsert(
+    {
+      user_id: userId,
+      column_order: column_order as unknown as Json,
+      hidden_columns: hidden_columns as unknown as Json,
+      updated_at: now,
+    },
+    { onConflict: "user_id" }
+  );
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}

--- a/src/lib/api/columnPreferences.ts
+++ b/src/lib/api/columnPreferences.ts
@@ -14,6 +14,8 @@ function parseStringArray(
 export type ColumnPreferences = {
   column_order: string[];
   hidden_columns: string[];
+  /** When prefs were last saved; used to merge in new custom columns without re-adding removed ones. */
+  prefs_updated_at: string | null;
 };
 
 export async function getColumnPreferencesForUser(
@@ -22,18 +24,23 @@ export async function getColumnPreferencesForUser(
   const client = createAdminClient();
   const { data, error } = await client
     .from("UserColumnPreferences")
-    .select("column_order, hidden_columns")
+    .select("column_order, hidden_columns, updated_at")
     .eq("user_id", userId)
     .maybeSingle();
 
   if (error) throw new Error(error.message);
   if (!data) {
-    return { column_order: [], hidden_columns: [] };
+    return {
+      column_order: [],
+      hidden_columns: [],
+      prefs_updated_at: null,
+    };
   }
 
   return {
     column_order: parseStringArray(data.column_order, []),
     hidden_columns: parseStringArray(data.hidden_columns, []),
+    prefs_updated_at: data.updated_at ?? null,
   };
 }
 

--- a/src/lib/api/columnPreferences.ts
+++ b/src/lib/api/columnPreferences.ts
@@ -2,6 +2,7 @@
 
 import { createAdminClient } from "@/lib/client/supabase/server";
 import type { Json } from "@/lib/client/supabase/types";
+import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
 
 function parseStringArray(
   json: Json | null | undefined,
@@ -39,7 +40,9 @@ export async function getColumnPreferencesForUser(
 
   return {
     column_order: parseStringArray(data.column_order, []),
-    hidden_columns: parseStringArray(data.hidden_columns, []),
+    hidden_columns: sanitizeHiddenColumnIds(
+      parseStringArray(data.hidden_columns, [])
+    ),
     prefs_updated_at: data.updated_at ?? null,
   };
 }
@@ -51,12 +54,13 @@ export async function saveColumnPreferencesForUser(
 ): Promise<{ success: boolean; error?: string }> {
   const client = createAdminClient();
   const now = new Date().toISOString();
+  const hiddenSafe = sanitizeHiddenColumnIds(hidden_columns);
 
   const { error } = await client.from("UserColumnPreferences").upsert(
     {
       user_id: userId,
       column_order: column_order as unknown as Json,
-      hidden_columns: hidden_columns as unknown as Json,
+      hidden_columns: hiddenSafe as unknown as Json,
       updated_at: now,
     },
     { onConflict: "user_id" }

--- a/src/lib/api/columnPreferences.ts
+++ b/src/lib/api/columnPreferences.ts
@@ -3,6 +3,13 @@
 import { createAdminClient } from "@/lib/client/supabase/server";
 import type { Json } from "@/lib/client/supabase/types";
 import { sanitizeHiddenColumnIds } from "@/lib/volunteerTable/columnVisibility";
+import {
+  BUILT_IN_VOLUNTEER_COLUMN_IDS,
+  orderedColumnIds,
+  tableIdForCustomColumn,
+} from "@/lib/volunteerTable/columnOrder";
+import { listCustomColumns } from "./customColumns";
+import { getVolunteerTableGlobalSettings } from "./volunteerTableGlobalSettings";
 
 function parseStringArray(
   json: Json | null | undefined,
@@ -18,6 +25,42 @@ export type ColumnPreferences = {
   /** When prefs were last saved; used to merge in new custom columns without re-adding removed ones. */
   prefs_updated_at: string | null;
 };
+
+/** Staff: merged hidden for table rendering; personal-only prefs remain in `hidden_columns`. */
+export type ColumnPreferencesWithStaffExtras = ColumnPreferences & {
+  hidden_columns_effective?: string[];
+};
+
+export async function resolveStaffColumnPreferences(
+  prefs: ColumnPreferences
+): Promise<ColumnPreferencesWithStaffExtras> {
+  const global = await getVolunteerTableGlobalSettings();
+  const excludeSet = new Set(global.admin_hidden_columns);
+  const allCustom = await listCustomColumns();
+  const visibleCustom = allCustom.filter(
+    (c) => !excludeSet.has(tableIdForCustomColumn(c.column_key))
+  );
+  const builtInIds = [...BUILT_IN_VOLUNTEER_COLUMN_IDS];
+  const savedOrderFiltered = prefs.column_order.filter(
+    (id) => !excludeSet.has(id)
+  );
+  const column_order = orderedColumnIds(
+    builtInIds,
+    visibleCustom,
+    savedOrderFiltered,
+    prefs.prefs_updated_at
+  ).filter((id) => !excludeSet.has(id));
+  const hidden_columns_effective = sanitizeHiddenColumnIds([
+    ...prefs.hidden_columns,
+    ...global.admin_hidden_columns,
+  ]);
+  return {
+    column_order,
+    hidden_columns: prefs.hidden_columns,
+    prefs_updated_at: prefs.prefs_updated_at,
+    hidden_columns_effective,
+  };
+}
 
 export async function getColumnPreferencesForUser(
   userId: string

--- a/src/lib/api/createVolunteer.ts
+++ b/src/lib/api/createVolunteer.ts
@@ -109,6 +109,18 @@ function validateVolunteerData(
     }
   }
 
+  if (data["custom_data"] !== undefined && data["custom_data"] !== null) {
+    if (
+      typeof data["custom_data"] !== "object" ||
+      Array.isArray(data["custom_data"])
+    ) {
+      errors.push({
+        field: "volunteer.custom_data",
+        message: "custom_data must be a plain object",
+      });
+    }
+  }
+
   return errors;
 }
 
@@ -266,7 +278,7 @@ function validateInput(input: unknown): ValidationError[] {
 }
 
 function volunteerToJson(volunteer: VolunteerInput): Record<string, unknown> {
-  return {
+  const row: Record<string, unknown> = {
     name_org: volunteer.name_org,
     pseudonym: volunteer.pseudonym ?? null,
     pronouns: volunteer.pronouns ?? null,
@@ -275,6 +287,16 @@ function volunteerToJson(volunteer: VolunteerInput): Record<string, unknown> {
     opt_in_communication: volunteer.opt_in_communication ?? true,
     notes: volunteer.notes ?? null,
   };
+  const cd = volunteer.custom_data;
+  if (
+    cd !== undefined &&
+    cd !== null &&
+    typeof cd === "object" &&
+    !Array.isArray(cd)
+  ) {
+    row["custom_data"] = cd;
+  }
+  return row;
 }
 
 /**

--- a/src/lib/api/customColumnUtils.ts
+++ b/src/lib/api/customColumnUtils.ts
@@ -1,0 +1,12 @@
+/** Pure helpers for custom column keys (not a Server Actions file). */
+
+export function slugifyColumnKey(name: string): string {
+  const raw = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  const base = raw.length > 0 ? raw : "column";
+  return /^[a-z]/.test(base) ? base : `c_${base}`;
+}

--- a/src/lib/api/customColumns.ts
+++ b/src/lib/api/customColumns.ts
@@ -1,0 +1,272 @@
+"use server";
+
+import { createAdminClient } from "@/lib/client/supabase/server";
+import type { Tables, TablesInsert } from "@/lib/client/supabase/types";
+
+export type CustomColumnRow = Tables<"CustomColumns">;
+
+const RESERVED_COLUMN_KEYS = new Set([
+  "id",
+  "volunteer_id",
+  "name_org",
+  "email",
+  "phone",
+  "pseudonym",
+  "pronouns",
+  "cohorts",
+  "prior_roles",
+  "current_roles",
+  "future_interests",
+  "opt_in_communication",
+  "notes",
+  "custom_data",
+  "position",
+  "created_at",
+  "updated_at",
+]);
+
+export function slugifyColumnKey(name: string): string {
+  const raw = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  const base = raw.length > 0 ? raw : "column";
+  return /^[a-z]/.test(base) ? base : `c_${base}`;
+}
+
+export async function listCustomColumns(): Promise<CustomColumnRow[]> {
+  const client = createAdminClient();
+  const { data, error } = await client
+    .from("CustomColumns")
+    .select("*")
+    .order("default_position", { ascending: true })
+    .order("id", { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export type NewCustomColumnInput = {
+  name: string;
+  data_type: "text" | "number" | "boolean" | "tag";
+  tag_options?: string[];
+  is_multi?: boolean;
+};
+
+export type ColumnMutationResult = {
+  success: boolean;
+  label: string;
+  error?: string;
+  id?: number;
+};
+
+async function nextDefaultPosition(
+  client: ReturnType<typeof createAdminClient>
+): Promise<number> {
+  const { data, error } = await client
+    .from("CustomColumns")
+    .select("default_position")
+    .order("default_position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  const max = data?.default_position ?? -1;
+  return max + 1;
+}
+
+export async function createCustomColumnsBatch(
+  columns: NewCustomColumnInput[],
+  createdBy: string | null
+): Promise<ColumnMutationResult[]> {
+  const client = createAdminClient();
+  const results: ColumnMutationResult[] = [];
+  let position = await nextDefaultPosition(client);
+
+  const existingKeys = new Set(
+    (await listCustomColumns()).map((r) => r.column_key)
+  );
+
+  for (const col of columns) {
+    const label = col.name.trim() || "(unnamed)";
+    let column_key = slugifyColumnKey(col.name);
+    if (RESERVED_COLUMN_KEYS.has(column_key) || existingKeys.has(column_key)) {
+      let n = 2;
+      let candidate = `${column_key}_${n}`;
+      while (
+        RESERVED_COLUMN_KEYS.has(candidate) ||
+        existingKeys.has(candidate)
+      ) {
+        n++;
+        candidate = `${column_key}_${n}`;
+      }
+      column_key = candidate;
+    }
+
+    if (!["text", "number", "boolean", "tag"].includes(col.data_type)) {
+      results.push({
+        success: false,
+        label,
+        error: "Invalid data type",
+      });
+      continue;
+    }
+
+    const row: TablesInsert<"CustomColumns"> = {
+      name: col.name.trim(),
+      column_key,
+      data_type: col.data_type,
+      tag_options:
+        col.data_type === "tag"
+          ? [
+              ...new Set(
+                (col.tag_options ?? []).map((t) => t.trim()).filter(Boolean)
+              ),
+            ]
+          : [],
+      is_multi: col.data_type === "tag" ? Boolean(col.is_multi) : false,
+      default_position: position,
+      created_by: createdBy,
+    };
+
+    const { data, error } = await client
+      .from("CustomColumns")
+      .insert(row)
+      .select("id")
+      .single();
+
+    if (error) {
+      results.push({
+        success: false,
+        label,
+        error: error.message,
+      });
+    } else {
+      existingKeys.add(column_key);
+      position += 1;
+      results.push({
+        success: true,
+        label: `${label} (${col.data_type})`,
+        id: data.id,
+      });
+    }
+  }
+
+  return results;
+}
+
+export async function deleteCustomColumnsBatch(
+  columnIds: number[]
+): Promise<ColumnMutationResult[]> {
+  const client = createAdminClient();
+  const results: ColumnMutationResult[] = [];
+
+  for (const id of columnIds) {
+    const { data: row, error: fetchErr } = await client
+      .from("CustomColumns")
+      .select("id, name, column_key")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (fetchErr) {
+      results.push({
+        success: false,
+        label: `ID ${id}`,
+        error: fetchErr.message,
+      });
+      continue;
+    }
+    if (!row) {
+      results.push({
+        success: false,
+        label: `ID ${id}`,
+        error: "Column not found",
+      });
+      continue;
+    }
+
+    const { error: rpcErr } = await client.rpc("remove_custom_column_data", {
+      p_column_key: row.column_key,
+    });
+    if (rpcErr) {
+      results.push({
+        success: false,
+        label: row.name,
+        error: rpcErr.message,
+      });
+      continue;
+    }
+
+    const { error: delErr } = await client
+      .from("CustomColumns")
+      .delete()
+      .eq("id", id);
+    if (delErr) {
+      results.push({
+        success: false,
+        label: row.name,
+        error: delErr.message,
+      });
+    } else {
+      results.push({
+        success: true,
+        label: `Delete “${row.name}”`,
+        id: row.id,
+      });
+    }
+  }
+
+  return results;
+}
+
+export type CustomColumnUpdate = {
+  name?: string;
+  tag_options?: string[];
+};
+
+export async function updateCustomColumn(
+  columnId: number,
+  patch: CustomColumnUpdate
+): Promise<{ success: boolean; error?: string }> {
+  const client = createAdminClient();
+
+  const { data: existing, error: fetchErr } = await client
+    .from("CustomColumns")
+    .select("id, data_type")
+    .eq("id", columnId)
+    .maybeSingle();
+
+  if (fetchErr) return { success: false, error: fetchErr.message };
+  if (!existing) return { success: false, error: "Column not found" };
+
+  const updates: Record<string, unknown> = {};
+  if (patch.name !== undefined) {
+    const n = patch.name.trim();
+    if (!n) return { success: false, error: "Name cannot be empty" };
+    updates["name"] = n;
+  }
+  if (patch.tag_options !== undefined) {
+    if (existing.data_type !== "tag") {
+      return {
+        success: false,
+        error: "tag_options only applies to tag columns",
+      };
+    }
+    updates["tag_options"] = [
+      ...new Set(patch.tag_options.map((t) => t.trim()).filter(Boolean)),
+    ];
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { success: true };
+  }
+
+  const { error } = await client
+    .from("CustomColumns")
+    .update(updates)
+    .eq("id", columnId);
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}

--- a/src/lib/api/customColumns.ts
+++ b/src/lib/api/customColumns.ts
@@ -2,6 +2,7 @@
 
 import { createAdminClient } from "@/lib/client/supabase/server";
 import type { Tables, TablesInsert } from "@/lib/client/supabase/types";
+import { slugifyColumnKey } from "./customColumnUtils";
 
 export type CustomColumnRow = Tables<"CustomColumns">;
 
@@ -24,17 +25,6 @@ const RESERVED_COLUMN_KEYS = new Set([
   "created_at",
   "updated_at",
 ]);
-
-export function slugifyColumnKey(name: string): string {
-  const raw = name
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .replace(/_+/g, "_");
-  const base = raw.length > 0 ? raw : "column";
-  return /^[a-z]/.test(base) ? base : `c_${base}`;
-}
 
 export async function listCustomColumns(): Promise<CustomColumnRow[]> {
   const client = createAdminClient();

--- a/src/lib/api/customColumns.ts
+++ b/src/lib/api/customColumns.ts
@@ -2,7 +2,12 @@
 
 import { createAdminClient } from "@/lib/client/supabase/server";
 import type { Tables, TablesInsert } from "@/lib/client/supabase/types";
+import { tableIdForCustomColumn } from "@/lib/volunteerTable/columnOrder";
 import { slugifyColumnKey } from "./customColumnUtils";
+import {
+  getVolunteerTableGlobalSettings,
+  saveVolunteerTableGlobalSettings,
+} from "./volunteerTableGlobalSettings";
 
 export type CustomColumnRow = Tables<"CustomColumns">;
 
@@ -152,6 +157,8 @@ export async function deleteCustomColumnsBatch(
 ): Promise<ColumnMutationResult[]> {
   const client = createAdminClient();
   const results: ColumnMutationResult[] = [];
+  /** Table ids (`custom__…`) to drop from org-wide hidden list when a column is removed. */
+  const removedCustomTableIds: string[] = [];
 
   for (const id of columnIds) {
     const { data: row, error: fetchErr } = await client
@@ -200,11 +207,23 @@ export async function deleteCustomColumnsBatch(
         error: delErr.message,
       });
     } else {
+      removedCustomTableIds.push(tableIdForCustomColumn(row.column_key));
       results.push({
         success: true,
         label: `Delete “${row.name}”`,
         id: row.id,
       });
+    }
+  }
+
+  if (removedCustomTableIds.length > 0) {
+    const removeSet = new Set(removedCustomTableIds);
+    const global = await getVolunteerTableGlobalSettings();
+    const nextHidden = global.admin_hidden_columns.filter(
+      (hid) => !removeSet.has(hid)
+    );
+    if (nextHidden.length !== global.admin_hidden_columns.length) {
+      await saveVolunteerTableGlobalSettings(nextHidden);
     }
   }
 

--- a/src/lib/api/getVolunteersByMultipleColumns.ts
+++ b/src/lib/api/getVolunteersByMultipleColumns.ts
@@ -1,13 +1,14 @@
 "use server";
 
 import { createClient } from "../client/supabase/server";
-import type { Database } from "../client/supabase/types";
+import type { Database, Tables } from "../client/supabase/types";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   BLANK_FIELD_FILTER_VALUE,
   CONTACT_INCOMPLETE_FIELD,
   CONTACT_INCOMPLETE_FILTER_VALUE,
 } from "../volunteerFilterShortcuts";
+import { listCustomColumns } from "./customColumns";
 
 const OP = {
   AND: "AND",
@@ -45,6 +46,10 @@ const ALLOWED_FIELDS = [
   CONTACT_INCOMPLETE_FIELD,
 ];
 
+const CUSTOM_COLUMN_FIELD_PREFIX = "custom__";
+
+type CustomColRow = Tables<"CustomColumns">;
+
 export type FilterTuple = {
   field: string;
   miniOp: "AND" | "OR";
@@ -52,7 +57,11 @@ export type FilterTuple = {
 };
 
 type ValidationResult =
-  | { valid: true; cleanedFiltersList: FilterTuple[] }
+  | {
+      valid: true;
+      cleanedFiltersList: FilterTuple[];
+      customColumns: CustomColRow[];
+    }
   | { valid: false; error: string };
 
 type VolunteerFilterResponse =
@@ -85,6 +94,7 @@ export async function getVolunteersByMultipleColumns(
   }
 
   const cleanFiltersList = validation.cleanedFiltersList;
+  const customColumns = validation.customColumns;
 
   const client = await createClient();
 
@@ -92,11 +102,29 @@ export async function getVolunteersByMultipleColumns(
     return { data: [] };
   }
 
+  const customColByField = new Map(
+    customColumns.map((c) => [
+      `${CUSTOM_COLUMN_FIELD_PREFIX}${c.column_key}`.toLowerCase(),
+      c,
+    ])
+  );
+
   try {
     const promises = cleanFiltersList.map(async (f) => {
       if (f.field === CONTACT_INCOMPLETE_FIELD) {
         return filterIdsContactIncomplete(client);
       }
+      
+      const customCol = customColByField.get(f.field);
+      if (customCol) {
+        return filterIdsByCustomColumn(
+          client,
+          customCol,
+          f.miniOp,
+          f.values as string[]
+        );
+      }
+
       if (
         f.field === "current_roles" ||
         f.field === "prior_roles" ||
@@ -161,6 +189,19 @@ export async function validateMultipleColumnFilter(
   if (!op || !(op === OP.AND || op === OP.OR))
     return { valid: false, error: "Invalid global operation" };
 
+  let customCols: CustomColRow[] = [];
+  try {
+    customCols = await listCustomColumns();
+  } catch {
+    customCols = [];
+  }
+
+  const customFieldSet = new Set(
+    customCols.map((c) =>
+      `${CUSTOM_COLUMN_FIELD_PREFIX}${c.column_key}`.toLowerCase()
+    )
+  );
+
   const cleanedFiltersList: FilterTuple[] = [];
 
   for (const inputF of filtersList) {
@@ -176,7 +217,10 @@ export async function validateMultipleColumnFilter(
     if (!f.field || typeof f.field !== "string")
       return { valid: false, error: "Invalid filter field" };
 
-    if (!f.field || !ALLOWED_FIELDS.includes(f.field))
+    if (
+      !f.field ||
+      (!ALLOWED_FIELDS.includes(f.field) && !customFieldSet.has(f.field))
+    )
       return { valid: false, error: "Invalid filter field name" };
 
     if (!Array.isArray(f.values) || f.values.length === 0)
@@ -212,7 +256,7 @@ export async function validateMultipleColumnFilter(
     cleanedFiltersList.push(f);
   }
 
-  return { valid: true, cleanedFiltersList };
+  return { valid: true, cleanedFiltersList, customColumns: customCols };
 }
 
 function filterMatchingIds(
@@ -341,6 +385,60 @@ async function filterIdsContactIncomplete(
       ids.add(row.id);
     }
   }
+  return ids;
+}
+
+async function filterIdsByCustomColumn(
+  client: SupabaseClient<Database>,
+  col: CustomColRow,
+  op: string,
+  values: string[]
+): Promise<Set<number>> {
+  const { data, error } = await client
+    .from("Volunteers")
+    .select("id, custom_data");
+  if (error) throw error;
+
+  const key = col.column_key;
+  const ids = new Set<number>();
+
+  for (const row of data ?? []) {
+    const raw = row.custom_data;
+    const obj =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : {};
+    const cell = obj[key];
+
+    const matchesOne = (needle: string): boolean => {
+      if (col.data_type === "text" || col.data_type === "number") {
+        const s = cell == null ? "" : String(cell);
+        return s.toLowerCase().includes(needle.toLowerCase());
+      }
+      if (col.data_type === "boolean") {
+        const yn =
+          needle.toLowerCase() === "yes" || needle.toLowerCase() === "true";
+        const nn =
+          needle.toLowerCase() === "no" || needle.toLowerCase() === "false";
+        if (yn) return cell === true || String(cell).toLowerCase() === "true";
+        if (nn) return cell === false || String(cell).toLowerCase() === "false";
+        return false;
+      }
+      if (col.data_type === "tag") {
+        if (col.is_multi) {
+          const arr = Array.isArray(cell) ? cell.map(String) : [];
+          return arr.includes(needle);
+        }
+        return String(cell ?? "") === needle;
+      }
+      return false;
+    };
+
+    const ok =
+      op === OP.OR ? values.some(matchesOne) : values.every(matchesOne);
+    if (ok) ids.add(row.id);
+  }
+
   return ids;
 }
 

--- a/src/lib/api/getVolunteersByMultipleColumns.ts
+++ b/src/lib/api/getVolunteersByMultipleColumns.ts
@@ -54,6 +54,8 @@ export type FilterTuple = {
   field: string;
   miniOp: "AND" | "OR";
   values: string[] | [string, string][];
+  /** Custom number columns: `values` is `[min, max]` inclusive; empty string means unbounded on that side. */
+  numberRange?: boolean;
 };
 
 type ValidationResult =
@@ -121,7 +123,8 @@ export async function getVolunteersByMultipleColumns(
           client,
           customCol,
           f.miniOp,
-          f.values as string[]
+          f.values as string[],
+          f.numberRange === true
         );
       }
 
@@ -247,6 +250,39 @@ export async function validateMultipleColumnFilter(
 
       if (invalid)
         return { valid: false, error: "Invalid cohort filter values" };
+    } else if (f.numberRange) {
+      const col = customCols.find(
+        (c) =>
+          `${CUSTOM_COLUMN_FIELD_PREFIX}${c.column_key}`.toLowerCase() ===
+          f.field
+      );
+      if (!col || col.data_type !== "number") {
+        return { valid: false, error: "Invalid number range filter field" };
+      }
+      const vals = f.values as string[];
+      if (!Array.isArray(vals) || vals.length !== 2) {
+        return { valid: false, error: "Number range requires min and max" };
+      }
+      const minS = String(vals[0] ?? "").trim();
+      const maxS = String(vals[1] ?? "").trim();
+      if (minS === "" && maxS === "") {
+        return {
+          valid: false,
+          error: "Enter at least a minimum or maximum for the range",
+        };
+      }
+      if (minS !== "" && !Number.isFinite(Number(minS))) {
+        return { valid: false, error: "Invalid minimum value" };
+      }
+      if (maxS !== "" && !Number.isFinite(Number(maxS))) {
+        return { valid: false, error: "Invalid maximum value" };
+      }
+      if (minS !== "" && maxS !== "" && Number(minS) > Number(maxS)) {
+        return {
+          valid: false,
+          error: "Minimum must be less than or equal to maximum",
+        };
+      }
     } else {
       const invalid = f.values.some((v) => typeof v !== "string");
       if (invalid)
@@ -388,11 +424,21 @@ async function filterIdsContactIncomplete(
   return ids;
 }
 
+function parseNumericCell(cell: unknown): number | null {
+  if (cell == null || cell === "") return null;
+  if (typeof cell === "number") {
+    return Number.isFinite(cell) ? cell : null;
+  }
+  const n = Number(String(cell).trim());
+  return Number.isFinite(n) ? n : null;
+}
+
 async function filterIdsByCustomColumn(
   client: SupabaseClient<Database>,
   col: CustomColRow,
   op: string,
-  values: string[]
+  values: string[],
+  numberRange = false
 ): Promise<Set<number>> {
   const { data, error } = await client
     .from("Volunteers")
@@ -409,6 +455,16 @@ async function filterIdsByCustomColumn(
         ? (raw as Record<string, unknown>)
         : {};
     const cell = obj[key];
+
+    if (col.data_type === "number" && numberRange && values.length === 2) {
+      const n = parseNumericCell(cell);
+      const minS = String(values[0] ?? "").trim();
+      const maxS = String(values[1] ?? "").trim();
+      const min = minS === "" ? -Infinity : Number(minS);
+      const max = maxS === "" ? Infinity : Number(maxS);
+      if (n !== null && n >= min && n <= max) ids.add(row.id);
+      continue;
+    }
 
     const matchesOne = (needle: string): boolean => {
       if (col.data_type === "text" || col.data_type === "number") {

--- a/src/lib/api/import_csv.ts
+++ b/src/lib/api/import_csv.ts
@@ -1,6 +1,6 @@
 import Papa, { ParseResult } from "papaparse";
 import { createClient } from "../client/supabase";
-import { Tables } from "../client/supabase/types";
+import type { Json, Tables } from "../client/supabase/types";
 
 type ImportCSVStatus = "success" | "partial_success" | "failed";
 
@@ -103,6 +103,104 @@ type ParseRowsInput = {
   rowData: Record<string, string | undefined>;
   rowIndex: number;
 };
+
+const CUSTOM_CSV_PREFIX = "custom:";
+
+type CustomColumnImportRow = Pick<
+  Tables<"CustomColumns">,
+  "column_key" | "data_type" | "tag_options" | "is_multi"
+>;
+
+function parseBooleanCsvCell(s: string): boolean | null {
+  const t = s.trim().toLowerCase();
+  if (["yes", "true", "1", "y"].includes(t)) return true;
+  if (["no", "false", "0", "n"].includes(t)) return false;
+  return null;
+}
+
+function splitCustomTagList(raw: string): string[] {
+  return raw
+    .split(/[,;]/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function parseCustomDataFromCsvRow(
+  rowData: Record<string, string | undefined>,
+  defs: CustomColumnImportRow[],
+  rowIndex: number
+): { custom_data: Record<string, unknown>; errors: RowParseError[] } {
+  const defByKey = new Map(defs.map((d) => [d.column_key, d]));
+  const custom_data: Record<string, unknown> = {};
+  const errors: RowParseError[] = [];
+
+  for (const [rawKey, rawVal] of Object.entries(rowData)) {
+    const keyLower = rawKey.toLowerCase().trim();
+    if (!keyLower.startsWith(CUSTOM_CSV_PREFIX)) continue;
+    const columnKey = keyLower.slice(CUSTOM_CSV_PREFIX.length).trim();
+    if (!columnKey) continue;
+
+    const def = defByKey.get(columnKey);
+    const cell = rawVal?.trim() ?? "";
+    if (!def) {
+      if (cell.length > 0) {
+        errors.push({
+          rowIndex,
+          column: rawKey,
+          value: cell,
+          message: `Unknown custom column key "${columnKey}" in CSV header`,
+        });
+      }
+      continue;
+    }
+    if (cell.length === 0) continue;
+
+    switch (def.data_type) {
+      case "text":
+        custom_data[columnKey] = cell;
+        break;
+      case "number": {
+        const n = Number(cell.replace(/,/g, ""));
+        if (Number.isNaN(n)) {
+          errors.push({
+            rowIndex,
+            column: rawKey,
+            value: cell,
+            message: `Invalid number for custom column "${columnKey}"`,
+          });
+        } else {
+          custom_data[columnKey] = n;
+        }
+        break;
+      }
+      case "boolean": {
+        const b = parseBooleanCsvCell(cell);
+        if (b === null) {
+          errors.push({
+            rowIndex,
+            column: rawKey,
+            value: cell,
+            message: `Expected Yes/No for custom column "${columnKey}"`,
+          });
+        } else {
+          custom_data[columnKey] = b;
+        }
+        break;
+      }
+      case "tag":
+        if (def.is_multi) {
+          custom_data[columnKey] = splitCustomTagList(cell);
+        } else {
+          custom_data[columnKey] = cell;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  return { custom_data, errors };
+}
 
 type ParseRowResult =
   | {
@@ -258,7 +356,8 @@ function parseRole(
 // fail parse if name/volunteer is blank
 function parseRow(
   rowData: Record<string, string | undefined>,
-  rowIndex: number
+  rowIndex: number,
+  customDefs: CustomColumnImportRow[] = []
 ): ParseRowResult {
   // known raw roles and names to map them as
 
@@ -351,6 +450,21 @@ function parseRow(
     }
   );
 
+  const customParsed = parseCustomDataFromCsvRow(rowData, customDefs, rowIndex);
+  rowParseErrors.push(...customParsed.errors);
+  if (Object.keys(customParsed.custom_data).length > 0) {
+    const prev =
+      result.custom_data &&
+      typeof result.custom_data === "object" &&
+      !Array.isArray(result.custom_data)
+        ? { ...(result.custom_data as Record<string, unknown>) }
+        : {};
+    result.custom_data = {
+      ...prev,
+      ...customParsed.custom_data,
+    } as ParsedVolunteer["custom_data"];
+  }
+
   if (rowParseErrors.length > 0) {
     return {
       ok: false,
@@ -366,13 +480,16 @@ function parseRow(
 }
 
 // Process all rows from parsed CSV and track row-level parse errors.
-function parseRows(rows: ParseRowsInput[]): ParseRowsResult {
+function parseRows(
+  rows: ParseRowsInput[],
+  customDefs: CustomColumnImportRow[] = []
+): ParseRowsResult {
   const volunteers: ParsedVolunteer[] = [];
   const rowErrors: RowParseError[] = [];
   const rowWarnings: RowParseWarning[] = [];
 
   rows.forEach(({ rowData, rowIndex }) => {
-    const parseResult = parseRow(rowData, rowIndex);
+    const parseResult = parseRow(rowData, rowIndex, customDefs);
 
     if (!parseResult.ok) {
       rowErrors.push(...parseResult.rowParseErrors);
@@ -485,16 +602,23 @@ export async function import_csv(
     })
     .filter(({ rowIndex }) => !papaErrorRowIndexes.has(rowIndex));
 
-  const {
-    volunteers,
-    rowErrors: rowParseErrors,
-    rowWarnings: rowParseWarnings,
-  } = parseRows(lowerCasedRows);
+  const client = await createClient();
+  const { data: customColRows } = await client
+    .from("CustomColumns")
+    .select("column_key, data_type, tag_options, is_multi")
+    .order("default_position", { ascending: true })
+    .order("id", { ascending: true });
+
+  const customImportDefs: CustomColumnImportRow[] = (customColRows ??
+    []) as CustomColumnImportRow[];
+
+  const { volunteers, rowErrors: rowParseErrors } = parseRows(
+    lowerCasedRows,
+    customImportDefs
+  );
   const rowDbErrors: RowDbError[] = [];
   let dbSucceeded = 0;
   let dbFailed = 0;
-
-  const client = await createClient();
 
   let dbInserted = 0;
   let dbUpdated = 0;
@@ -502,6 +626,14 @@ export async function import_csv(
   const changedDetails: Array<{ name: string; fields: string[] }> = [];
 
   for (const volunteer of volunteers) {
+    const customPayload =
+      volunteer.custom_data &&
+      typeof volunteer.custom_data === "object" &&
+      !Array.isArray(volunteer.custom_data) &&
+      Object.keys(volunteer.custom_data).length > 0
+        ? (volunteer.custom_data as Json)
+        : null;
+
     const { data: rpcResult, error } = await client.rpc(
       "upsert_volunteer_with_roles_and_cohorts",
       {
@@ -513,6 +645,7 @@ export async function import_csv(
         p_cohort: volunteer.cohort,
         p_roles: volunteer.roles,
         p_notes: volunteer.notes,
+        p_custom_data: customPayload,
       }
     );
 
@@ -634,4 +767,5 @@ export const __testables = {
   parseRow,
   parseRows,
   validateHeaders,
+  parseCustomDataFromCsvRow,
 };

--- a/src/lib/api/import_csv.ts
+++ b/src/lib/api/import_csv.ts
@@ -125,6 +125,7 @@ function createEmptyVolunteer(): ParsedVolunteer {
   return {
     index: -1,
     name_org: "",
+    custom_data: {},
     pronouns: null,
     email: null,
     phone: null,

--- a/src/lib/api/updateVolunteer.ts
+++ b/src/lib/api/updateVolunteer.ts
@@ -121,9 +121,6 @@ function normalizeCustomFieldValue(
   }
 
   if (def.data_type === "tag") {
-    const allowed = new Set((def.tag_options ?? []).filter(Boolean));
-    const requireOption = allowed.size > 0;
-
     if (def.is_multi) {
       if (!Array.isArray(raw)) {
         return {
@@ -134,16 +131,6 @@ function normalizeCustomFieldValue(
       const tags = [
         ...new Set(raw.map((x) => String(x).trim()).filter(Boolean)),
       ].sort();
-      if (requireOption) {
-        for (const t of tags) {
-          if (!allowed.has(t)) {
-            return {
-              ok: false,
-              error: `Invalid tag "${t}" for "${def.column_key}"`,
-            };
-          }
-        }
-      }
       return { ok: true, value: tags };
     }
 
@@ -155,9 +142,6 @@ function normalizeCustomFieldValue(
     }
     const t = raw.trim();
     if (t === "") return { ok: true, value: null };
-    if (requireOption && !allowed.has(t)) {
-      return { ok: false, error: `Invalid tag "${t}" for "${def.column_key}"` };
-    }
     return { ok: true, value: t };
   }
 

--- a/src/lib/api/updateVolunteer.ts
+++ b/src/lib/api/updateVolunteer.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createAdminClient } from "../client/supabase/server";
-import type { Tables, TablesUpdate } from "../client/supabase/types";
+import type { Json, Tables, TablesUpdate } from "../client/supabase/types";
 
 const ROLE_TYPES = ["prior", "current", "future_interest"] as const;
 const COHORT_TERMS = ["fall", "summer", "winter", "spring"] as const;
@@ -34,6 +34,7 @@ type UpdateVolunteerResult =
 
 type VolunteerValidationResult = {
   updates?: Partial<VolunteerUpdatePayload>;
+  customDataPatch?: Record<string, unknown>;
   role?: RoleInput;
   cohort?: CohortInput;
   roles?: RoleInput[];
@@ -54,11 +55,161 @@ const ALLOWED_VOLUNTEER_FIELDS = new Set<keyof VolunteerUpdatePayload>([
 ]);
 const ALLOWED_TOP_LEVEL_FIELDS = new Set<string>([
   ...ALLOWED_VOLUNTEER_FIELDS,
+  "custom_data",
   "role",
   "cohort",
   "roles",
   "cohorts",
 ]);
+
+type CustomColDef = Pick<
+  Tables<"CustomColumns">,
+  "column_key" | "data_type" | "tag_options" | "is_multi"
+>;
+
+function normalizeCustomFieldValue(
+  def: CustomColDef,
+  raw: unknown
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  if (raw === null) {
+    return { ok: true, value: null };
+  }
+
+  if (def.data_type === "text") {
+    if (typeof raw !== "string")
+      return {
+        ok: false,
+        error: `Custom "${def.column_key}" must be a string or null`,
+      };
+    const t = raw.trim();
+    return { ok: true, value: t === "" ? null : raw };
+  }
+
+  if (def.data_type === "number") {
+    if (raw === "") return { ok: true, value: null };
+    if (typeof raw === "number") {
+      if (!Number.isFinite(raw))
+        return {
+          ok: false,
+          error: `Custom "${def.column_key}" must be a finite number`,
+        };
+      return { ok: true, value: raw };
+    }
+    if (typeof raw === "string") {
+      const s = raw.trim();
+      if (s === "") return { ok: true, value: null };
+      const n = Number(s);
+      if (!Number.isFinite(n))
+        return {
+          ok: false,
+          error: `Custom "${def.column_key}" must be a number`,
+        };
+      return { ok: true, value: n };
+    }
+    return {
+      ok: false,
+      error: `Custom "${def.column_key}" must be a number or null`,
+    };
+  }
+
+  if (def.data_type === "boolean") {
+    if (typeof raw === "boolean") return { ok: true, value: raw };
+    return {
+      ok: false,
+      error: `Custom "${def.column_key}" must be a boolean or null`,
+    };
+  }
+
+  if (def.data_type === "tag") {
+    const allowed = new Set((def.tag_options ?? []).filter(Boolean));
+    const requireOption = allowed.size > 0;
+
+    if (def.is_multi) {
+      if (!Array.isArray(raw)) {
+        return {
+          ok: false,
+          error: `Custom "${def.column_key}" must be an array of tags or null`,
+        };
+      }
+      const tags = [
+        ...new Set(raw.map((x) => String(x).trim()).filter(Boolean)),
+      ].sort();
+      if (requireOption) {
+        for (const t of tags) {
+          if (!allowed.has(t)) {
+            return {
+              ok: false,
+              error: `Invalid tag "${t}" for "${def.column_key}"`,
+            };
+          }
+        }
+      }
+      return { ok: true, value: tags };
+    }
+
+    if (typeof raw !== "string") {
+      return {
+        ok: false,
+        error: `Custom "${def.column_key}" must be a string tag or null`,
+      };
+    }
+    const t = raw.trim();
+    if (t === "") return { ok: true, value: null };
+    if (requireOption && !allowed.has(t)) {
+      return { ok: false, error: `Invalid tag "${t}" for "${def.column_key}"` };
+    }
+    return { ok: true, value: t };
+  }
+
+  return { ok: false, error: `Unknown data type for "${def.column_key}"` };
+}
+
+async function mergeVolunteerCustomData(
+  client: ReturnType<typeof createAdminClient>,
+  volunteerId: number,
+  patch: Record<string, unknown>
+): Promise<{ ok: true; merged: Json } | { ok: false; error: string }> {
+  const { data: defs, error: defErr } = await client
+    .from("CustomColumns")
+    .select("column_key, data_type, tag_options, is_multi");
+
+  if (defErr) return { ok: false, error: defErr.message };
+  const byKey = new Map((defs ?? []).map((d) => [d.column_key, d]));
+
+  const { data: row, error: rowErr } = await client
+    .from("Volunteers")
+    .select("custom_data")
+    .eq("id", volunteerId)
+    .maybeSingle();
+
+  if (rowErr) return { ok: false, error: rowErr.message };
+
+  const base =
+    row?.custom_data &&
+    typeof row.custom_data === "object" &&
+    !Array.isArray(row.custom_data)
+      ? { ...(row.custom_data as Record<string, unknown>) }
+      : {};
+
+  for (const [key, raw] of Object.entries(patch)) {
+    const def = byKey.get(key);
+    if (!def) {
+      return { ok: false, error: `Unknown custom column key: ${key}` };
+    }
+    const norm = normalizeCustomFieldValue(def, raw);
+    if (!norm.ok) {
+      return { ok: false, error: norm.error };
+    }
+    const v = norm.value;
+    if (v === null || v === undefined) {
+      delete base[key];
+    } else {
+      base[key] = v;
+    }
+  }
+
+  return { ok: true, merged: base as Json };
+}
 
 function validateVolunteerUpdateBody(body: unknown): VolunteerValidationResult {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -137,7 +288,22 @@ function validateVolunteerUpdateBody(body: unknown): VolunteerValidationResult {
     }
   }
 
+  let customDataPatch: Record<string, unknown> | undefined;
+  if ("custom_data" in payload) {
+    const cd = payload["custom_data"];
+    if (cd === undefined) {
+      /* not patching custom_data */
+    } else if (cd === null || typeof cd !== "object" || Array.isArray(cd)) {
+      return { error: "Field custom_data must be an object" };
+    } else {
+      customDataPatch = { ...(cd as Record<string, unknown>) };
+    }
+  }
+
   const hasFields = Object.keys(updates).length > 0;
+  const hasCustomPatch =
+    customDataPatch !== undefined && Object.keys(customDataPatch).length > 0;
+
   let role: RoleInput | undefined;
   let cohort: CohortInput | undefined;
   let roles: RoleInput[] | undefined;
@@ -245,14 +411,16 @@ function validateVolunteerUpdateBody(body: unknown): VolunteerValidationResult {
     }
   }
 
-  if (!hasFields && !role && !cohort && !roles && !cohorts) {
+  if (!hasFields && !role && !cohort && !roles && !cohorts && !hasCustomPatch) {
     return {
       error:
-        "At least one updatable field is required (volunteer fields, role, or cohort)",
+        "At least one updatable field is required (volunteer fields, role, cohort, or custom_data)",
     };
   }
 
   const result: VolunteerValidationResult = { updates };
+  if (hasCustomPatch && customDataPatch)
+    result.customDataPatch = customDataPatch;
   if (role) result.role = role;
   if (cohort) result.cohort = cohort;
   if (roles) result.roles = roles;
@@ -270,7 +438,7 @@ export async function updateVolunteer(
   }
 
   const validation = validateVolunteerUpdateBody(body);
-  if (!validation.updates) {
+  if (validation.error || validation.updates === undefined) {
     return {
       status: 400,
       body: { error: validation.error ?? "Invalid volunteer update payload" },
@@ -279,6 +447,22 @@ export async function updateVolunteer(
 
   const client = createAdminClient();
   const timestamp = new Date().toISOString();
+
+  let mergedCustomData: Json | undefined;
+  if (
+    validation.customDataPatch &&
+    Object.keys(validation.customDataPatch).length > 0
+  ) {
+    const merged = await mergeVolunteerCustomData(
+      client,
+      volunteerId as number,
+      validation.customDataPatch
+    );
+    if (!merged.ok) {
+      return { status: 400, body: { error: merged.error } };
+    }
+    mergedCustomData = merged.merged;
+  }
 
   let roleRow: { id: number } | null = null;
   if (validation.role) {
@@ -373,7 +557,13 @@ export async function updateVolunteer(
 
   const { data: volunteer, error: volunteerError } = await client
     .from("Volunteers")
-    .update({ ...validation.updates, updated_at: timestamp })
+    .update({
+      ...validation.updates,
+      ...(mergedCustomData !== undefined
+        ? { custom_data: mergedCustomData }
+        : {}),
+      updated_at: timestamp,
+    })
     .eq("id", volunteerId as number)
     .select()
     .maybeSingle();

--- a/src/lib/api/volunteerTableGlobalSettings.ts
+++ b/src/lib/api/volunteerTableGlobalSettings.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { createAdminClient } from "../client/supabase/server";
+import type { Json } from "../client/supabase/types";
+import { sanitizeHiddenColumnIds } from "../volunteerTable/columnVisibility";
+
+const SINGLETON_ID = 1;
+
+export type VolunteerTableGlobalSettings = {
+  admin_hidden_columns: string[];
+};
+
+export async function getVolunteerTableGlobalSettings(): Promise<VolunteerTableGlobalSettings> {
+  const client = createAdminClient();
+  const { data, error } = await client
+    .from("VolunteerTableGlobalSettings")
+    .select("admin_hidden_columns")
+    .eq("id", SINGLETON_ID)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) {
+    return { admin_hidden_columns: [] };
+  }
+  const raw = data.admin_hidden_columns;
+  if (!Array.isArray(raw)) {
+    return { admin_hidden_columns: [] };
+  }
+  return {
+    admin_hidden_columns: sanitizeHiddenColumnIds(
+      raw.filter((x): x is string => typeof x === "string")
+    ),
+  };
+}
+
+export async function saveVolunteerTableGlobalSettings(
+  admin_hidden_columns: string[]
+): Promise<{ success: boolean; error?: string }> {
+  const client = createAdminClient();
+  const now = new Date().toISOString();
+  const safe = sanitizeHiddenColumnIds(admin_hidden_columns);
+  const { error } = await client.from("VolunteerTableGlobalSettings").upsert(
+    {
+      id: SINGLETON_ID,
+      admin_hidden_columns: safe as unknown as Json,
+      updated_at: now,
+    },
+    { onConflict: "id" }
+  );
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}

--- a/src/lib/client/supabase/types.ts
+++ b/src/lib/client/supabase/types.ts
@@ -335,8 +335,9 @@ export type Database = {
           p_cohort: Json | null;
           p_roles: Json;
           p_notes: string | null;
+          p_custom_data?: Json | null;
         };
-        Returns: number;
+        Returns: Json;
       };
       remove_custom_column_data: {
         Args: { p_column_key: string };

--- a/src/lib/client/supabase/types.ts
+++ b/src/lib/client/supabase/types.ts
@@ -181,6 +181,24 @@ export type Database = {
           },
         ];
       };
+      VolunteerTableGlobalSettings: {
+        Row: {
+          admin_hidden_columns: Json;
+          id: number;
+          updated_at: string | null;
+        };
+        Insert: {
+          admin_hidden_columns?: Json;
+          id?: number;
+          updated_at?: string | null;
+        };
+        Update: {
+          admin_hidden_columns?: Json;
+          id?: number;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       VolunteerCohorts: {
         Row: {
           cohort_id: number;

--- a/src/lib/client/supabase/types.ts
+++ b/src/lib/client/supabase/types.ts
@@ -63,6 +63,50 @@ export type Database = {
         };
         Relationships: [];
       };
+      CustomColumns: {
+        Row: {
+          column_key: string;
+          created_at: string | null;
+          created_by: string | null;
+          data_type: string;
+          default_position: number;
+          id: number;
+          is_multi: boolean;
+          name: string;
+          tag_options: string[] | null;
+        };
+        Insert: {
+          column_key: string;
+          created_at?: string | null;
+          created_by?: string | null;
+          data_type: string;
+          default_position?: number;
+          id?: number;
+          is_multi?: boolean;
+          name: string;
+          tag_options?: string[] | null;
+        };
+        Update: {
+          column_key?: string;
+          created_at?: string | null;
+          created_by?: string | null;
+          data_type?: string;
+          default_position?: number;
+          id?: number;
+          is_multi?: boolean;
+          name?: string;
+          tag_options?: string[] | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "CustomColumns_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "Users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       Roles: {
         Row: {
           created_at: string;
@@ -107,6 +151,35 @@ export type Database = {
           role?: Database["public"]["Enums"]["user_roles"] | null;
         };
         Relationships: [];
+      };
+      UserColumnPreferences: {
+        Row: {
+          column_order: Json;
+          hidden_columns: Json;
+          updated_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          column_order?: Json;
+          hidden_columns?: Json;
+          updated_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          column_order?: Json;
+          hidden_columns?: Json;
+          updated_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "UserColumnPreferences_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: true;
+            referencedRelation: "Users";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       VolunteerCohorts: {
         Row: {
@@ -177,6 +250,7 @@ export type Database = {
       Volunteers: {
         Row: {
           created_at: string;
+          custom_data: Json;
           email: string | null;
           id: number;
           name_org: string;
@@ -190,6 +264,7 @@ export type Database = {
         };
         Insert: {
           created_at?: string;
+          custom_data?: Json;
           email?: string | null;
           id?: number;
           name_org: string;
@@ -203,6 +278,7 @@ export type Database = {
         };
         Update: {
           created_at?: string;
+          custom_data?: Json;
           email?: string | null;
           id?: number;
           name_org?: string;
@@ -261,6 +337,10 @@ export type Database = {
           p_notes: string | null;
         };
         Returns: number;
+      };
+      remove_custom_column_data: {
+        Args: { p_column_key: string };
+        Returns: undefined;
       };
     };
     Enums: {

--- a/src/lib/volunteerTable/columnOrder.ts
+++ b/src/lib/volunteerTable/columnOrder.ts
@@ -1,0 +1,80 @@
+import type { CustomColumnRow } from "@/lib/api/customColumns";
+
+/** Must match the order of entries in `COLUMNS_CONFIG` (volunteerColumns.tsx). */
+export const BUILT_IN_VOLUNTEER_COLUMN_IDS: readonly string[] = [
+  "volunteer_id",
+  "name_org",
+  "pseudonym",
+  "pronouns",
+  "email",
+  "phone",
+  "cohorts",
+  "prior_roles",
+  "current_roles",
+  "future_interests",
+  "opt_in_communication",
+  "notes",
+];
+
+export const CUSTOM_COLUMN_ID_PREFIX = "custom__";
+
+export function tableIdForCustomColumn(columnKey: string): string {
+  return `${CUSTOM_COLUMN_ID_PREFIX}${columnKey}`;
+}
+
+export function parseCustomColumnTableId(columnId: string): string | null {
+  if (!columnId.startsWith(CUSTOM_COLUMN_ID_PREFIX)) return null;
+  return columnId.slice(CUSTOM_COLUMN_ID_PREFIX.length);
+}
+
+export function orderedColumnIds(
+  builtInIds: string[],
+  customColumns: CustomColumnRow[],
+  savedOrder: string[],
+  /** When set, custom columns with created_at at or before this time are not auto-appended if missing from savedOrder (e.g. removed from prefs but not yet deleted in DB). */
+  prefsUpdatedAt?: string | null
+): string[] {
+  const customSorted = [...customColumns].sort(
+    (a, b) => a.default_position - b.default_position || a.id - b.id
+  );
+  const customIds = customSorted.map((c) =>
+    tableIdForCustomColumn(c.column_key)
+  );
+  const allKnown = [...builtInIds, ...customIds];
+
+  if (savedOrder.length === 0) {
+    return allKnown;
+  }
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of savedOrder) {
+    if (!allKnown.includes(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  for (const id of builtInIds) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  const prefsTime = prefsUpdatedAt ? Date.parse(prefsUpdatedAt) : NaN;
+  for (const c of customSorted) {
+    const id = tableIdForCustomColumn(c.column_key);
+    if (seen.has(id)) continue;
+    const created =
+      c.created_at != null && c.created_at !== ""
+        ? Date.parse(c.created_at)
+        : NaN;
+    const appendNewCustom =
+      !Number.isFinite(prefsTime) ||
+      !Number.isFinite(created) ||
+      created > prefsTime;
+    if (appendNewCustom) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}

--- a/src/lib/volunteerTable/columnVisibility.ts
+++ b/src/lib/volunteerTable/columnVisibility.ts
@@ -1,0 +1,10 @@
+/** Built-in columns that must always remain visible (personal prefs, org prefs, and UI). */
+export const NON_HIDEABLE_COLUMN_IDS: readonly string[] = [
+  "volunteer_id",
+  "opt_in_communication",
+];
+
+export function sanitizeHiddenColumnIds(ids: string[]): string[] {
+  const banned = new Set(NON_HIDEABLE_COLUMN_IDS);
+  return ids.filter((id) => !banned.has(id));
+}

--- a/src/lib/volunteerTable/mergeCustomTagOptionsFromVolunteers.ts
+++ b/src/lib/volunteerTable/mergeCustomTagOptionsFromVolunteers.ts
@@ -1,0 +1,67 @@
+import type { CustomColumnRow } from "@/lib/api/customColumns";
+import type { Volunteer } from "@/components/volunteers/types";
+
+function collectTagValues(raw: unknown): string[] {
+  if (raw == null) return [];
+  if (Array.isArray(raw)) {
+    return raw.map((x) => String(x).trim()).filter((s) => s.length > 0);
+  }
+  const s = String(raw).trim();
+  return s.length > 0 ? [s] : [];
+}
+
+/**
+ * For each custom tag column, returns a copy with `tag_options` including:
+ * - existing presets from `CustomColumns.tag_options` (order preserved, de-duplicated)
+ * - every distinct value stored in volunteer `custom_data` for that column
+ * - values from unsaved `editedRows` patches (optional)
+ *
+ * Cell-created tags (typed in the grid) live only in `custom_data` until promoted here or in Manage Tags.
+ */
+export function mergeCustomTagOptionsFromVolunteers(
+  columns: CustomColumnRow[],
+  volunteers: Volunteer[],
+  editedRows?: Record<number, Partial<Volunteer>>
+): CustomColumnRow[] {
+  return columns.map((c) => {
+    if (c.data_type !== "tag") return c;
+
+    const ck = c.column_key;
+    const baseOrder = [
+      ...new Set(
+        (c.tag_options ?? []).map((t) => t.trim()).filter((t) => t.length > 0)
+      ),
+    ];
+    const seen = new Set<string>(baseOrder);
+
+    for (const v of volunteers) {
+      const cd = v.custom_data;
+      if (cd && typeof cd === "object" && !Array.isArray(cd)) {
+        for (const t of collectTagValues((cd as Record<string, unknown>)[ck])) {
+          seen.add(t);
+        }
+      }
+    }
+
+    if (editedRows) {
+      for (const edit of Object.values(editedRows)) {
+        const cd = edit?.custom_data;
+        if (cd && typeof cd === "object" && !Array.isArray(cd)) {
+          for (const t of collectTagValues(
+            (cd as Record<string, unknown>)[ck]
+          )) {
+            seen.add(t);
+          }
+        }
+      }
+    }
+
+    const extra = [...seen].filter((t) => !baseOrder.includes(t));
+    extra.sort((a, b) => a.localeCompare(b));
+
+    return {
+      ...c,
+      tag_options: [...baseOrder, ...extra],
+    };
+  });
+}

--- a/supabase/migrations/20260405120000_custom_columns.sql
+++ b/supabase/migrations/20260405120000_custom_columns.sql
@@ -1,0 +1,39 @@
+-- Custom column definitions (admin-managed)
+CREATE TABLE public."CustomColumns" (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  column_key text UNIQUE NOT NULL,
+  data_type text NOT NULL CHECK (data_type IN ('text', 'number', 'boolean', 'tag')),
+  tag_options text[] DEFAULT '{}',
+  is_multi boolean DEFAULT false,
+  default_position integer NOT NULL DEFAULT 0,
+  created_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES public."Users"(id)
+);
+
+ALTER TABLE public."Volunteers"
+  ADD COLUMN IF NOT EXISTS custom_data jsonb DEFAULT '{}'::jsonb;
+
+CREATE TABLE public."UserColumnPreferences" (
+  user_id uuid PRIMARY KEY REFERENCES public."Users"(id) ON DELETE CASCADE,
+  column_order jsonb DEFAULT '[]'::jsonb,
+  hidden_columns jsonb DEFAULT '[]'::jsonb,
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.remove_custom_column_data(p_column_key text)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE public."Volunteers"
+  SET custom_data = custom_data - p_column_key
+  WHERE custom_data ? p_column_key;
+$$;
+
+ALTER TABLE public."CustomColumns" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."UserColumnPreferences" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "full permission for development phase" ON public."CustomColumns" TO anon USING (true) WITH CHECK (true);
+CREATE POLICY "full permission for development phase" ON public."UserColumnPreferences" TO anon USING (true) WITH CHECK (true);

--- a/supabase/migrations/20260406130000_volunteer_rpcs_custom_data.sql
+++ b/supabase/migrations/20260406130000_volunteer_rpcs_custom_data.sql
@@ -1,0 +1,290 @@
+-- Persist custom_data on volunteer create (modal) and optional merge on CSV upsert.
+
+CREATE OR REPLACE FUNCTION public.create_volunteer_with_roles_and_cohorts(
+  p_volunteer jsonb,
+  p_roles jsonb,
+  p_cohorts jsonb
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_volunteer_id bigint;
+  v_role jsonb;
+  v_role_name text;
+  v_role_type text;
+  v_role_id bigint;
+  v_cohort jsonb;
+  v_cohort_year smallint;
+  v_cohort_term text;
+  v_cohort_id bigint;
+  v_custom jsonb;
+BEGIN
+  v_custom := COALESCE(p_volunteer -> 'custom_data', '{}'::jsonb);
+  IF jsonb_typeof(v_custom) IS DISTINCT FROM 'object' THEN
+    v_custom := '{}'::jsonb;
+  END IF;
+
+  INSERT INTO public."Volunteers" (
+    name_org,
+    pseudonym,
+    pronouns,
+    email,
+    phone,
+    position,
+    opt_in_communication,
+    notes,
+    custom_data
+  )
+  VALUES (
+    (p_volunteer ->> 'name_org'),
+    NULLIF(TRIM(p_volunteer ->> 'pseudonym'), ''),
+    NULLIF(TRIM(p_volunteer ->> 'pronouns'), ''),
+    NULLIF(TRIM(p_volunteer ->> 'email'), ''),
+    NULLIF(TRIM(p_volunteer ->> 'phone'), ''),
+    NULL,
+    COALESCE((p_volunteer ->> 'opt_in_communication')::boolean, true),
+    NULLIF(TRIM(p_volunteer ->> 'notes'), ''),
+    v_custom
+  )
+  RETURNING id INTO v_volunteer_id;
+
+  IF v_volunteer_id IS NULL THEN
+    RAISE EXCEPTION 'Failed to insert volunteer';
+  END IF;
+
+  FOR v_role IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_roles, '[]'::jsonb))
+  LOOP
+    v_role_name := NULLIF(TRIM(v_role ->> 'name'), '');
+    v_role_type := NULLIF(TRIM(v_role ->> 'type'), '');
+    IF v_role_name IS NULL OR v_role_type IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    SELECT id
+      INTO v_role_id
+    FROM public."Roles"
+    WHERE name = v_role_name
+      AND type = v_role_type
+      AND is_active = true
+    ORDER BY id
+    LIMIT 1;
+
+    IF v_role_id IS NULL THEN
+      INSERT INTO public."Roles" (name, type)
+      VALUES (v_role_name, v_role_type)
+      RETURNING id INTO v_role_id;
+    END IF;
+
+    IF v_role_id IS NOT NULL THEN
+      INSERT INTO public."VolunteerRoles" (volunteer_id, role_id)
+      VALUES (v_volunteer_id, v_role_id)
+      ON CONFLICT ON CONSTRAINT "VolunteerRoles_pkey" DO NOTHING;
+    END IF;
+  END LOOP;
+
+  FOR v_cohort IN
+    SELECT value FROM jsonb_array_elements(COALESCE(p_cohorts, '[]'::jsonb))
+  LOOP
+    IF TRIM(COALESCE(v_cohort ->> 'year', '')) !~ '^\d+$' THEN
+      CONTINUE;
+    END IF;
+
+    v_cohort_year := (v_cohort ->> 'year')::smallint;
+    v_cohort_term := NULLIF(TRIM(v_cohort ->> 'term'), '');
+
+    IF v_cohort_term IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    SELECT id
+      INTO v_cohort_id
+    FROM public."Cohorts"
+    WHERE year = v_cohort_year AND term = v_cohort_term
+    LIMIT 1;
+
+    IF v_cohort_id IS NULL THEN
+      INSERT INTO public."Cohorts" (year, term)
+      VALUES (v_cohort_year, v_cohort_term)
+      RETURNING id INTO v_cohort_id;
+    END IF;
+
+    IF v_cohort_id IS NOT NULL THEN
+      INSERT INTO public."VolunteerCohorts" (volunteer_id, cohort_id)
+      VALUES (v_volunteer_id, v_cohort_id)
+      ON CONFLICT ON CONSTRAINT "VolunteerCohorts_pkey" DO NOTHING;
+    END IF;
+  END LOOP;
+
+  RETURN v_volunteer_id;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.upsert_volunteer_with_roles_and_cohorts(text, text, text, text, text, jsonb, jsonb, text);
+
+CREATE OR REPLACE FUNCTION public.upsert_volunteer_with_roles_and_cohorts(
+	p_name text,
+	p_pronouns text,
+	p_email text,
+	p_phone text,
+	p_position text,
+	p_cohort jsonb,
+	p_roles jsonb,
+	p_notes text,
+	p_custom_data jsonb DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+	v_volunteer_id bigint;
+	v_role jsonb;
+	v_role_name text;
+	v_role_status text;
+	v_role_id bigint;
+	v_role_type_seed text;
+	v_year smallint;
+	v_term text;
+	v_cohort_id bigint;
+	v_link_role_id bigint;
+	v_role_ids jsonb := '[]'::jsonb;
+  	v_cohort_info jsonb := NULL;
+BEGIN
+	p_name := NULLIF(TRIM(p_name), '');
+	p_email := NULLIF(TRIM(p_email), '');
+	p_position := lower(NULLIF(TRIM(p_position), ''));
+	p_pronouns := NULLIF(TRIM(p_pronouns), '');
+	p_phone := NULLIF(TRIM(p_phone), '');
+	p_notes := NULLIF(TRIM(p_notes), '');
+
+	IF p_custom_data IS NOT NULL AND jsonb_typeof(p_custom_data) IS DISTINCT FROM 'object' THEN
+		p_custom_data := '{}'::jsonb;
+	END IF;
+
+	-- Upsert by same (name_org, email) using strict equality.
+	SELECT id
+		INTO v_volunteer_id
+	FROM public."Volunteers"
+	WHERE name_org = p_name
+		AND email = p_email
+	ORDER BY id
+	LIMIT 1;
+
+	IF v_volunteer_id IS NULL THEN
+		INSERT INTO public."Volunteers" (
+			name_org,
+			pronouns,
+			email,
+			phone,
+			position,
+			notes,
+			custom_data
+		)
+		VALUES (
+			p_name,
+			p_pronouns,
+			p_email,
+			p_phone,
+			p_position,
+			p_notes,
+			COALESCE(p_custom_data, '{}'::jsonb)
+		)
+		RETURNING id INTO v_volunteer_id;
+	ELSE
+		UPDATE public."Volunteers"
+		SET
+			pronouns = p_pronouns,
+			email = p_email,
+			phone = p_phone,
+			position = p_position,
+			notes = p_notes,
+			custom_data = CASE
+				WHEN p_custom_data IS NULL THEN custom_data
+				ELSE COALESCE(custom_data, '{}'::jsonb) || p_custom_data
+			END,
+			updated_at = now()
+		WHERE id = v_volunteer_id;
+	END IF;
+
+	-- Add-only behavior: keep existing links and insert missing links from payload.
+	-- Roles payload shape: [{"name": "Front Desk", "status": "current"}, ...]
+	FOR v_role IN
+		SELECT value FROM jsonb_array_elements(COALESCE(p_roles, '[]'::jsonb))
+	LOOP
+		v_role_name := NULLIF(TRIM(v_role ->> 'name'), '');
+		v_role_status := lower(NULLIF(TRIM(v_role ->> 'status'), ''));
+		v_link_role_id := NULL;
+
+		FOREACH v_role_type_seed IN ARRAY ARRAY['prior', 'current', 'future_interest']
+		LOOP
+			-- Prefer existing active role for this (name, type)
+			SELECT id
+				INTO v_role_id
+			FROM public."Roles"
+			WHERE name = v_role_name
+				AND type = v_role_type_seed
+				AND is_active = true
+			ORDER BY id
+			LIMIT 1;
+
+			-- If not found, create and capture id. is_active defaults to true
+			IF v_role_id IS NULL THEN
+				INSERT INTO public."Roles" (name, type)
+				VALUES (v_role_name, v_role_type_seed)
+				RETURNING id INTO v_role_id;
+			END IF;
+
+			-- Keep the id for the status we need to link
+			IF v_role_type_seed = v_role_status THEN
+				v_link_role_id := v_role_id;
+			END IF;
+		END LOOP;
+
+		INSERT INTO public."VolunteerRoles" (volunteer_id, role_id)
+		VALUES (v_volunteer_id, v_link_role_id)
+		ON CONFLICT DO NOTHING;
+	END LOOP;
+
+	-- Cohort payload shape: {"year": 2025, "season": "Summer"}
+	IF p_cohort IS NOT NULL THEN
+
+		IF TRIM(p_cohort ->> 'year') !~ '^\d+$' THEN
+			RAISE EXCEPTION 'Invalid cohort year in payload: %', p_cohort;
+		END IF;
+
+		v_year := (p_cohort ->> 'year')::smallint;
+		v_term := NULLIF(TRIM(p_cohort ->> 'season'), '');
+
+		SELECT id
+			INTO v_cohort_id
+		FROM public."Cohorts"
+		WHERE year = v_year
+			AND term = v_term
+		ORDER BY id
+			LIMIT 1;
+
+		IF v_cohort_id IS NULL THEN
+			INSERT INTO public."Cohorts" (year, term)
+			VALUES (v_year, v_term)
+			RETURNING id INTO v_cohort_id;
+		END IF;
+
+		INSERT INTO public."VolunteerCohorts" (volunteer_id, cohort_id)
+		VALUES (v_volunteer_id, v_cohort_id)
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN v_volunteer_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_volunteer_with_roles_and_cohorts(text, text, text, text, text, jsonb, jsonb, text, jsonb) IS
+	'Upserts volunteer by (name_org,email), merges optional p_custom_data into custom_data, ensures roles/cohorts exist, and inserts missing VolunteerRoles/VolunteerCohorts links.';
+
+GRANT EXECUTE ON FUNCTION public.upsert_volunteer_with_roles_and_cohorts(text, text, text, text, text, jsonb, jsonb, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.upsert_volunteer_with_roles_and_cohorts(text, text, text, text, text, jsonb, jsonb, text, jsonb) TO service_role;

--- a/supabase/migrations/20260407120000_volunteer_table_global_settings.sql
+++ b/supabase/migrations/20260407120000_volunteer_table_global_settings.sql
@@ -1,0 +1,13 @@
+-- Organization-wide volunteer table column visibility (admin-managed).
+-- Merged with each user's UserColumnPreferences.hidden_columns when rendering the table.
+CREATE TABLE public."VolunteerTableGlobalSettings" (
+  id smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  admin_hidden_columns jsonb NOT NULL DEFAULT '[]'::jsonb,
+  updated_at timestamptz DEFAULT now()
+);
+
+INSERT INTO public."VolunteerTableGlobalSettings" (id) VALUES (1);
+
+ALTER TABLE public."VolunteerTableGlobalSettings" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "full permission for development phase" ON public."VolunteerTableGlobalSettings" TO anon USING (true) WITH CHECK (true);

--- a/tests/lib/api/getVolunteersByMultipleColumns.test.ts
+++ b/tests/lib/api/getVolunteersByMultipleColumns.test.ts
@@ -115,6 +115,21 @@ describe("validateMultipleColumnFilter (unit)", () => {
     if (!result.valid)
       expect(result.error).toMatch(/Invalid general or role filter values/);
   });
+
+  it("rejects number range on non-number fields", async () => {
+    const filtersList: FilterTuple[] = [
+      {
+        field: "name_org",
+        miniOp: "AND",
+        values: ["1", "5"],
+        numberRange: true,
+      },
+    ];
+    const result = await validateMultipleColumnFilter(filtersList, "OR");
+    expect(result.valid).toBe(false);
+    if (!result.valid)
+      expect(result.error).toMatch(/Invalid number range filter field/);
+  });
 });
 
 // Integration tests

--- a/tests/lib/api/import_csv.parsers.test.ts
+++ b/tests/lib/api/import_csv.parsers.test.ts
@@ -11,6 +11,7 @@ const {
   parseRow,
   parseRows,
   validateHeaders,
+  parseCustomDataFromCsvRow,
 } = __testables;
 
 describe("import_csv helper functions", () => {
@@ -375,6 +376,60 @@ describe("import_csv helper functions", () => {
 
     it("returns all required headers for empty input", () => {
       expect(validateHeaders([])).toHaveLength(2);
+    });
+  });
+
+  describe("parseCustomDataFromCsvRow", () => {
+    const col = (
+      column_key: string,
+      data_type: string,
+      extra: { is_multi?: boolean; tag_options?: string[] | null } = {}
+    ): {
+      column_key: string;
+      data_type: string;
+      tag_options: string[] | null;
+      is_multi: boolean;
+    } => ({
+      column_key,
+      data_type,
+      tag_options: extra.tag_options ?? null,
+      is_multi: extra.is_multi ?? false,
+    });
+
+    it("maps custom:text and ignores empty cells", () => {
+      const { custom_data, errors } = parseCustomDataFromCsvRow(
+        { "custom:note": "hello", volunteer: "x" },
+        [col("note", "text")],
+        1
+      );
+      expect(custom_data).toEqual({ note: "hello" });
+      expect(errors).toHaveLength(0);
+    });
+
+    it("errors on unknown custom key with a value", () => {
+      const { custom_data, errors } = parseCustomDataFromCsvRow(
+        { "custom:unknown": "x" },
+        [col("note", "text")],
+        2
+      );
+      expect(Object.keys(custom_data)).toHaveLength(0);
+      expect(errors.some((e) => e.message.includes("Unknown custom"))).toBe(
+        true
+      );
+    });
+
+    it("parses boolean and multi-tag values", () => {
+      const { custom_data, errors } = parseCustomDataFromCsvRow(
+        {
+          "custom:active": "yes",
+          "custom:skills": "a; b, c",
+        },
+        [col("active", "boolean"), col("skills", "tag", { is_multi: true })],
+        0
+      );
+      expect(custom_data["active"]).toBe(true);
+      expect(custom_data["skills"]).toEqual(["a", "b", "c"]);
+      expect(errors).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Had to make many changes to implement this (including changes to the database). 
- Created new tables in the database and a new field for the Supabase Volunteers table
- Added a new button with a pop-up for reorganizing columns in the table
- Added a new page in settings for table settings (only admins can view)

You can test both Staff and Admin views to check if it works. I tested thoroughly, but I may've missed something. Check for edge cases. I caught a lot of minor bugs.

<img width="1470" height="831" alt="Screenshot 2026-04-06 at 18 21 27" src="https://github.com/user-attachments/assets/db9a3d2d-ec43-414b-accc-4db8ac668626" />
<img width="1470" height="835" alt="Screenshot 2026-04-06 at 18 21 31" src="https://github.com/user-attachments/assets/3ae226bd-347d-40e7-92a8-52398cbfe801" />
<img width="1470" height="833" alt="Screenshot 2026-04-06 at 18 21 49" src="https://github.com/user-attachments/assets/aa74ff05-79d6-401e-b7af-92f2de0d8f10" />
<img width="1470" height="834" alt="Screenshot 2026-04-06 at 18 21 53" src="https://github.com/user-attachments/assets/64b365b3-c273-4c87-a7bf-f5797650feaf" />
